### PR TITLE
Suppress (thousands of) warnings when building with GCC

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -222,6 +222,17 @@ endif()
 set(FAISS_HEADERS ${FAISS_HEADERS} PARENT_SCOPE)
 
 add_library(faiss ${FAISS_SRC})
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(
+    faiss PRIVATE
+    "-Wno-sign-compare"
+    "-Wno-unused-function"
+    "-Wno-unused-variable"
+    "-Wno-redundant-decls"
+    "-Wno-maybe-uninitialized"
+    "-Wno-format"
+  )
+endif()
 
 add_library(faiss_avx2 ${FAISS_SRC})
 if(NOT FAISS_OPT_LEVEL STREQUAL "avx2")


### PR DESCRIPTION
Without this change (most notably -Wno-sign-compare), building faiss produces nearly 2MB of warning output.