### PR TITLE
Introducing a new reader to read index using a pointer

### DIFF
--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -19,13 +19,13 @@ using faiss::IndexBinary;
 
 int faiss_write_index_buf(const FaissIndex* idx, int* size, unsigned char** buf) {
     try {
-        faiss::BufIOWriter writer;
-
-        writer.buf = (uint8_t*)malloc(writer.buf_cap * sizeof(uint8_t));
+        faiss::VectorIOWriter writer;
         faiss::write_index(reinterpret_cast<const Index*>(idx), &writer);
-        *buf = writer.buf;
-        *size = writer.buf_size;
-        writer.buf = NULL;
+        unsigned char* tempBuf = (unsigned char*)malloc((writer.data.size()) * sizeof(uint8_t));
+        std::copy(writer.data.begin(), writer.data.end(), tempBuf);
+        *buf = tempBuf;
+        *size = writer.data.size();
+        writer.data.clear();
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -19,13 +19,13 @@ using faiss::IndexBinary;
 
 int faiss_write_index_buf(const FaissIndex* idx, int* size, unsigned char** buf) {
     try {
-        faiss::VectorIOWriter writer;
+        faiss::BufIOWriter writer;
+
+        writer.buf = (uint8_t*)malloc(writer.buf_cap * sizeof(uint8_t));
         faiss::write_index(reinterpret_cast<const Index*>(idx), &writer);
-        unsigned char* tempBuf = (unsigned char*)malloc((writer.data.size()) * sizeof(uint8_t));
-        std::copy(writer.data.begin(), writer.data.end(), tempBuf);
-        *buf = tempBuf;
-        *size = writer.data.size();
-        writer.data.clear();
+        *buf = writer.buf;
+        *size = writer.buf_size;
+        writer.buf = NULL;
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -31,10 +31,20 @@ int faiss_write_index_buf(const FaissIndex* idx, int* size, unsigned char** buf)
     CATCH_AND_HANDLE
 }
 
+int checksum(const unsigned char* buf, int size) {
+
+    for (int i = 0; i < size; i++) {
+
+    }
+
+    return 0;
+}
+
 int faiss_read_index_buf(const unsigned char* buf, int size, int io_flags, FaissIndex** p_out) {
     try {
         faiss::VectorIOReader reader;
         reader.data.assign(buf, buf + size);
+        printf("the error while reading index from ptr %p of size %d\n", buf, size);
         auto index = faiss::read_index(&reader, io_flags);
         *p_out = reinterpret_cast<FaissIndex*>(index);
     }

--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -20,7 +20,6 @@ using faiss::IndexBinary;
 int faiss_write_index_buf(const FaissIndex* idx, int* size, unsigned char** buf) {
     try {
         faiss::VectorIOWriter writer;
-
         faiss::write_index(reinterpret_cast<const Index*>(idx), &writer);
         unsigned char* tempBuf = (unsigned char*)malloc((writer.data.size()) * sizeof(uint8_t));
         std::copy(writer.data.begin(), writer.data.end(), tempBuf);
@@ -31,20 +30,11 @@ int faiss_write_index_buf(const FaissIndex* idx, int* size, unsigned char** buf)
     CATCH_AND_HANDLE
 }
 
-int checksum(const unsigned char* buf, int size) {
-
-    for (int i = 0; i < size; i++) {
-
-    }
-
-    return 0;
-}
-
-int faiss_read_index_buf(const unsigned char* buf, int size, int io_flags, FaissIndex** p_out) {
+int faiss_read_index_buf(const uint8_t* buf, int size, int io_flags, FaissIndex** p_out) {
     try {
-        faiss::VectorIOReader reader;
-        reader.data.assign(buf, buf + size);
-        printf("the error while reading index from ptr %p of size %d\n", buf, size);
+        faiss::BufIOReader reader;
+        reader.buf = buf;
+        reader.buf_size = size;
         auto index = faiss::read_index(&reader, io_flags);
         *p_out = reinterpret_cast<FaissIndex*>(index);
     }

--- a/faiss/impl/io.cpp
+++ b/faiss/impl/io.cpp
@@ -37,6 +37,7 @@ size_t VectorIOWriter::operator()(const void* ptr, size_t size, size_t nitems) {
     if (bytes > 0) {
         size_t o = data.size();
         data.resize(o + bytes);
+        //  printf("performing a memcpy ptr %p data %p\n", ptr, &data[0]);
         memcpy(&data[o], ptr, size * nitems);
     }
     return nitems;
@@ -59,18 +60,6 @@ size_t VectorIOReader::operator()(void* ptr, size_t size, size_t nitems) {
  * IO Buffer
  ***********************************************************************/
 
-// size_t BufIOWriter::operator()(const void* ptr, size_t size, size_t nitems) {
-//      size_t bytes = size * nitems;
-//     if (bytes > 0) {
-//         size_t o = buf_size;
-//         // data.resize(o + bytes);
-//         // memcpy(&data[o], ptr, size * nitems);
-//         buf = (uint8_t*) realloc(buf, o + bytes);
-//         memcpy(&buf[o], ptr, size * nitems);
-//     }
-//     return nitems;
-// }
-
 size_t BufIOReader::operator()(void* ptr, size_t size, size_t nitems) {
     if (rp >= buf_size)
         return 0;
@@ -86,7 +75,7 @@ size_t BufIOReader::operator()(void* ptr, size_t size, size_t nitems) {
 }
 
 BufIOReader::~BufIOReader() {
-    free(buf);
+    buf = NULL;
 }
 
 /***********************************************************************

--- a/faiss/impl/io.cpp
+++ b/faiss/impl/io.cpp
@@ -37,7 +37,6 @@ size_t VectorIOWriter::operator()(const void* ptr, size_t size, size_t nitems) {
     if (bytes > 0) {
         size_t o = data.size();
         data.resize(o + bytes);
-        //  printf("performing a memcpy ptr %p data %p\n", ptr, &data[0]);
         memcpy(&data[o], ptr, size * nitems);
     }
     return nitems;
@@ -59,6 +58,31 @@ size_t VectorIOReader::operator()(void* ptr, size_t size, size_t nitems) {
 /***********************************************************************
  * IO Buffer
  ***********************************************************************/
+
+size_t BufIOWriter::operator()(const void* ptr, size_t size, size_t nitems) {
+    size_t bytes = size * nitems;
+    if (bytes > 0) {
+        size_t o = buf_size;
+        bool growing = false;
+        if (buf_cap == 0) {
+            buf_cap = o + bytes;
+            growing = true;
+        }
+        while(o + bytes > buf_cap){
+            buf_cap = buf_cap * 2;
+            growing = true;
+        }
+        if (growing){
+            buf = (uint8_t*) realloc(buf, buf_cap);
+        }
+
+        memcpy(&buf[o], ptr, size * nitems);
+        buf_size += (size*nitems);
+    }
+    return nitems;
+}
+
+BufIOWriter::~BufIOWriter() {}
 
 size_t BufIOReader::operator()(void* ptr, size_t size, size_t nitems) {
     if (rp >= buf_size)

--- a/faiss/impl/io.cpp
+++ b/faiss/impl/io.cpp
@@ -59,31 +59,6 @@ size_t VectorIOReader::operator()(void* ptr, size_t size, size_t nitems) {
  * IO Buffer
  ***********************************************************************/
 
-size_t BufIOWriter::operator()(const void* ptr, size_t size, size_t nitems) {
-    size_t bytes = size * nitems;
-    if (bytes > 0) {
-        size_t o = buf_size;
-        bool growing = false;
-        if (buf_cap == 0) {
-            buf_cap = o + bytes;
-            growing = true;
-        }
-        while(o + bytes > buf_cap){
-            buf_cap = buf_cap * 2;
-            growing = true;
-        }
-        if (growing){
-            buf = (uint8_t*) realloc(buf, buf_cap);
-        }
-
-        memcpy(&buf[o], ptr, size * nitems);
-        buf_size += (size*nitems);
-    }
-    return nitems;
-}
-
-BufIOWriter::~BufIOWriter() {}
-
 size_t BufIOReader::operator()(void* ptr, size_t size, size_t nitems) {
     if (rp >= buf_size)
         return 0;

--- a/faiss/impl/io.cpp
+++ b/faiss/impl/io.cpp
@@ -60,12 +60,19 @@ size_t VectorIOReader::operator()(void* ptr, size_t size, size_t nitems) {
  ***********************************************************************/
 
 size_t BufIOReader::operator()(void* ptr, size_t size, size_t nitems) {
+    // if the read pointer has passed the buffer size, exit out since we've
+    // read the complete index
     if (rp >= buf_size)
         return 0;
+
+    // check how many "items" of a particular size are to be read from the buffer
+    // the size of the item depends on the datatype of field being populated.
     size_t nremain = (buf_size - rp) / size;
-    if (nremain < nitems)
-        nitems = nremain;
+    if (nremain < nitems) // we don't have enough items to be read, in which case
+        nitems = nremain; // read all the remaining ones
     if (size * nitems > 0) {
+        // finally memcpy the data from buffer to the field of the index being
+        // populated and increment the read pointer.
         memcpy(ptr, &buf[rp], size * nitems);
         rp += size * nitems;
     }

--- a/faiss/impl/io.cpp
+++ b/faiss/impl/io.cpp
@@ -56,6 +56,40 @@ size_t VectorIOReader::operator()(void* ptr, size_t size, size_t nitems) {
 }
 
 /***********************************************************************
+ * IO Buffer
+ ***********************************************************************/
+
+// size_t BufIOWriter::operator()(const void* ptr, size_t size, size_t nitems) {
+//      size_t bytes = size * nitems;
+//     if (bytes > 0) {
+//         size_t o = buf_size;
+//         // data.resize(o + bytes);
+//         // memcpy(&data[o], ptr, size * nitems);
+//         buf = (uint8_t*) realloc(buf, o + bytes);
+//         memcpy(&buf[o], ptr, size * nitems);
+//     }
+//     return nitems;
+// }
+
+size_t BufIOReader::operator()(void* ptr, size_t size, size_t nitems) {
+    if (rp >= buf_size)
+        return 0;
+    size_t nremain = (buf_size - rp) / size;
+    if (nremain < nitems)
+        nitems = nremain;
+    if (size * nitems > 0) {
+        memcpy(ptr, &buf[rp], size * nitems);
+        rp += size * nitems;
+    }
+
+    return nitems;
+}
+
+BufIOReader::~BufIOReader() {
+    free(buf);
+}
+
+/***********************************************************************
  * IO File
  ***********************************************************************/
 

--- a/faiss/impl/io.h
+++ b/faiss/impl/io.h
@@ -61,6 +61,21 @@ struct VectorIOWriter : IOWriter {
     size_t operator()(const void* ptr, size_t size, size_t nitems) override;
 };
 
+// struct BufIOWriter : IOWriter {
+//     uint8_t* buf;
+//     size_t buf_size;
+//     size_t operator()(const void* ptr, size_t size, size_t nitems) override;
+//     ~BufIOWriter() override;
+// }
+
+struct BufIOReader : IOReader {
+    uint8_t* buf;
+    size_t rp = 0;
+    size_t buf_size;
+    size_t operator()(void* ptr, size_t size, size_t nitems) override;
+    ~BufIOReader() override;
+};
+
 struct FileIOReader : IOReader {
     FILE* f = nullptr;
     bool need_close = false;

--- a/faiss/impl/io.h
+++ b/faiss/impl/io.h
@@ -61,6 +61,16 @@ struct VectorIOWriter : IOWriter {
     size_t operator()(const void* ptr, size_t size, size_t nitems) override;
 };
 
+struct BufIOWriter : IOWriter {
+    uint8_t* buf;
+    size_t buf_size = 0;
+    // default it to zero. the capacity is to be initialized when
+    // the read operation is performed for the first time with a chunk of data.
+    size_t buf_cap = 0;
+    size_t operator()(const void* ptr, size_t size, size_t nitems) override;
+    ~BufIOWriter() override;
+};
+
 struct BufIOReader : IOReader {
     const uint8_t* buf;
     size_t rp = 0;

--- a/faiss/impl/io.h
+++ b/faiss/impl/io.h
@@ -61,15 +61,8 @@ struct VectorIOWriter : IOWriter {
     size_t operator()(const void* ptr, size_t size, size_t nitems) override;
 };
 
-// struct BufIOWriter : IOWriter {
-//     uint8_t* buf;
-//     size_t buf_size;
-//     size_t operator()(const void* ptr, size_t size, size_t nitems) override;
-//     ~BufIOWriter() override;
-// }
-
 struct BufIOReader : IOReader {
-    uint8_t* buf;
+    const uint8_t* buf;
     size_t rp = 0;
     size_t buf_size;
     size_t operator()(void* ptr, size_t size, size_t nitems) override;

--- a/faiss/impl/io.h
+++ b/faiss/impl/io.h
@@ -61,16 +61,6 @@ struct VectorIOWriter : IOWriter {
     size_t operator()(const void* ptr, size_t size, size_t nitems) override;
 };
 
-struct BufIOWriter : IOWriter {
-    uint8_t* buf;
-    size_t buf_size = 0;
-    // default it to zero. the capacity is to be initialized when
-    // the read operation is performed for the first time with a chunk of data.
-    size_t buf_cap = 0;
-    size_t operator()(const void* ptr, size_t size, size_t nitems) override;
-    ~BufIOWriter() override;
-};
-
 struct BufIOReader : IOReader {
     const uint8_t* buf;
     size_t rp = 0;


### PR DESCRIPTION
While reading an index from a buffer having serialized index content earlier we were using the `VectorIOReader`. However when there is a large number of IO operations happening, profiling shows that the destructor call of the class adds up to the latency while serving the query (during which we read the index from the index file). 

This PR introduces a new class called `BufIOReader` which as uint8_t* as the backing buffer - or rather a pointer to the array passed to the faiss_read_index_buf() function. There isn't extra allocation happening over here unlike the VectorIOReader since its a pointer unlike the STL vector maintained in the VectorIOReader. Furthermore, the destructor call is cheap where we are assigning the pointer to NULL and the memory block is freed up by the calling layer of this function. 

Some latency numbers with and without the change on 1M sift dataset (on couchbase build):
-  single partition without PR - 6.6s, with PR - 3.671s.
- six partitions without PR - 3.58s, with PR - 2.333s 
