### PR TITLE
Adding a function to create an IDSelectorArray

### DIFF
--- a/c_api/impl/AuxIndexStructures_c.cpp
+++ b/c_api/impl/AuxIndexStructures_c.cpp
@@ -20,6 +20,7 @@ using faiss::DistanceComputer;
 using faiss::IDSelector;
 using faiss::IDSelectorAnd;
 using faiss::IDSelectorBatch;
+using faiss::IDSelectorArray;
 using faiss::IDSelectorNot;
 using faiss::IDSelectorOr;
 using faiss::IDSelectorRange;
@@ -115,6 +116,18 @@ int faiss_IDSelectorBatch_new(
     try {
         *p_sel = reinterpret_cast<FaissIDSelectorBatch*>(
                 new IDSelectorBatch(n, indices));
+        return 0;
+    }
+    CATCH_AND_HANDLE
+}
+
+int faiss_IDSelectorArray_new(
+        FaissIDSelectorArray** p_sel,
+        size_t n,
+        const idx_t* indices) {
+    try {
+        *p_sel = reinterpret_cast<FaissIDSelectorArray*>(
+                new IDSelectorArray(n, indices));
         return 0;
     }
     CATCH_AND_HANDLE

--- a/c_api/impl/AuxIndexStructures_c.h
+++ b/c_api/impl/AuxIndexStructures_c.h
@@ -66,6 +66,13 @@ int faiss_IDSelectorRange_new(
         idx_t imin,
         idx_t imax);
 
+FAISS_DECLARE_CLASS(IDSelectorArray)
+
+int faiss_IDSelectorArray_new(
+        FaissIDSelectorArray** p_sel,
+        size_t n,
+        const idx_t* indices);
+
 /** Remove ids from a set. Repetitions of ids in the indices set
  * passed to the constructor does not hurt performance. The hash
  * function used for the bloom filter and GCC's implementation of


### PR DESCRIPTION
This PR adds a function in the c_api which will enable users of the C API(eg. go-faiss) to create an ID Selector array.