### PR TITLE
MB-60202 - IDMap2 Selector

### DIFF
--- a/c_api/IndexIVF_c_ex.cpp
+++ b/c_api/IndexIVF_c_ex.cpp
@@ -12,11 +12,23 @@
 #include "macros_impl.h"
 
 using faiss::IndexIVF;
+using faiss::SearchParametersIVF;
 
 int faiss_IndexIVF_set_direct_map(FaissIndexIVF* index, int direct_map_type) {
     try {
         reinterpret_cast<IndexIVF*>(index)->set_direct_map_type(
                 static_cast<faiss::DirectMap::Type>(direct_map_type));
+    }
+    CATCH_AND_HANDLE
+}
+
+int faiss_SearchParametersIVF_new_with_sel(
+        FaissSearchParametersIVF** p_sp,
+        FaissIDSelector* sel) {
+    try {
+        SearchParametersIVF* sp = new SearchParametersIVF;
+        sp->sel = reinterpret_cast<faiss::IDSelector*>(sel);
+        *p_sp = reinterpret_cast<FaissSearchParametersIVF*>(sp);
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/IndexIVF_c_ex.h
+++ b/c_api/IndexIVF_c_ex.h
@@ -23,6 +23,10 @@ int faiss_IndexIVF_set_direct_map(
         FaissIndexIVF* index,
         int direct_map_type);
 
+int faiss_SearchParametersIVF_new_with_sel(
+        FaissSearchParametersIVF** p_sp,
+        FaissIDSelector* sel);
+
 #ifdef __cplusplus
 }
 #endif

--- a/faiss/IndexIDMap.h
+++ b/faiss/IndexIDMap.h
@@ -9,6 +9,7 @@
 
 #include <faiss/Index.h>
 #include <faiss/IndexBinary.h>
+#include <faiss/impl/IDSelector.h>
 
 #include <unordered_map>
 #include <vector>
@@ -101,5 +102,26 @@ struct IndexIDMap2Template : IndexIDMapTemplate<IndexT> {
 
 using IndexIDMap2 = IndexIDMap2Template<Index>;
 using IndexBinaryIDMap2 = IndexIDMap2Template<IndexBinary>;
+
+// IDSelector that translates the ids using an IDMap
+struct IDSelectorTranslated : IDSelector {
+    const std::vector<int64_t>& id_map;
+    const IDSelector* sel;
+
+    IDSelectorTranslated(
+            const std::vector<int64_t>& id_map,
+            const IDSelector* sel)
+            : id_map(id_map), sel(sel) {}
+
+    IDSelectorTranslated(IndexBinaryIDMap& index_idmap, const IDSelector* sel)
+            : id_map(index_idmap.id_map), sel(sel) {}
+
+    IDSelectorTranslated(IndexIDMap& index_idmap, const IDSelector* sel)
+            : id_map(index_idmap.id_map), sel(sel) {}
+
+    bool is_member(idx_t id) const override {
+        return sel->is_member(id_map[id]);
+    }
+};
 
 } // namespace faiss

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -192,6 +192,7 @@ add_ref_in_constructor(IDSelectorNot, 0)
 add_ref_in_constructor(IDSelectorAnd, slice(2))
 add_ref_in_constructor(IDSelectorOr, slice(2))
 add_ref_in_constructor(IDSelectorXOr, slice(2))
+add_ref_in_constructor(IDSelectorTranslated, slice(2))
 
 # seems really marginal...
 # remove_ref_from_method(IndexReplicas, 'removeIndex', 0)

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -494,11 +494,6 @@ void gpu_sync_all_devices()
 %template(IndexBinaryReplicas) faiss::IndexReplicasTemplate<faiss::IndexBinary>;
 
 %include  <faiss/MetaIndexes.h>
-%include  <faiss/IndexIDMap.h>
-%template(IndexIDMap) faiss::IndexIDMapTemplate<faiss::Index>;
-%template(IndexBinaryIDMap) faiss::IndexIDMapTemplate<faiss::IndexBinary>;
-%template(IndexIDMap2) faiss::IndexIDMap2Template<faiss::Index>;
-%template(IndexBinaryIDMap2) faiss::IndexIDMap2Template<faiss::IndexBinary>;
 
 %include  <faiss/IndexRowwiseMinMax.h>
 
@@ -512,6 +507,13 @@ void gpu_sync_all_devices()
 
 %include <faiss/impl/AuxIndexStructures.h>
 %include <faiss/impl/IDSelector.h>
+
+%include  <faiss/IndexIDMap.h>
+%template(IndexIDMap) faiss::IndexIDMapTemplate<faiss::Index>;
+%template(IndexBinaryIDMap) faiss::IndexIDMapTemplate<faiss::IndexBinary>;
+%template(IndexIDMap2) faiss::IndexIDMap2Template<faiss::Index>;
+%template(IndexBinaryIDMap2) faiss::IndexIDMap2Template<faiss::IndexBinary>;
+
 
 %include <faiss/utils/approx_topk/mode.h>
 


### PR DESCRIPTION
This PR 
- cherry picks a [commit](https://github.com/blevesearch/faiss/commit/eabe59958384d7d85aaa76a16dca9b5053ff276e) which adds a selector which accounts for the user provided custom vector IDs when searching within a FAISS index.
- adds a helper function to set the selector for IVF search parameters.