### PR TITLE
MB-60657: Fix integer overflow

### DIFF
--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -17,7 +17,7 @@
 using faiss::Index;
 using faiss::IndexBinary;
 
-int faiss_write_index_buf(const FaissIndex* idx, int* size, unsigned char** buf) {
+int faiss_write_index_buf(const FaissIndex* idx, size_t* size, unsigned char** buf) {
     try {
         faiss::VectorIOWriter writer;
         faiss::write_index(reinterpret_cast<const Index*>(idx), &writer);

--- a/c_api/index_io_c_ex.h
+++ b/c_api/index_io_c_ex.h
@@ -23,7 +23,7 @@ extern "C" {
 
 /** Write index to buffer
  */
-int faiss_write_index_buf(const FaissIndex* idx, int* buf_size, unsigned char** buf);
+int faiss_write_index_buf(const FaissIndex* idx, size_t* buf_size, unsigned char** buf);
 
 /** Read index from buffer
  */


### PR DESCRIPTION
- The `std::vector<T>.size()` gives a value of type unsigned integer - `size_t`. But by assigning it to a variable of type `int` we end up getting negative values for the size in case of an overflow.