### PR TITLE
MB-60739: Fix integer overflow

### DIFF
--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -30,7 +30,7 @@ int faiss_write_index_buf(const FaissIndex* idx, size_t* size, unsigned char** b
     CATCH_AND_HANDLE
 }
 
-int faiss_read_index_buf(const uint8_t* buf, int size, int io_flags, FaissIndex** p_out) {
+int faiss_read_index_buf(const uint8_t* buf, size_t size, int io_flags, FaissIndex** p_out) {
     try {
         faiss::BufIOReader reader;
         reader.buf = buf;

--- a/c_api/index_io_c_ex.h
+++ b/c_api/index_io_c_ex.h
@@ -27,7 +27,7 @@ int faiss_write_index_buf(const FaissIndex* idx, size_t* buf_size, unsigned char
 
 /** Read index from buffer
  */
-int faiss_read_index_buf(const unsigned char* buf, int limit, int io_flags,
+int faiss_read_index_buf(const unsigned char* buf, size_t limit, int io_flags,
         FaissIndex** p_out);
 
 #ifdef __cplusplus


### PR DESCRIPTION
- When we typecast `len(buf)` to a `C.int`, we're essentially converting a 64-bit integer (int64) to a 32-bit integer (int32), on 64-bit systems. This conversion causes an overflow, leading to the number wrapping around to a false value. Consequently, this results in only a partial read of the buffer, which then triggers an exception when attempting to deserialize the buffer into a Faiss index.
- This alternative approach sets the datatype of the receiver to `size_t`, which can accommodate all `int64` values without any wraparound issues.