### PR TITLE
MB-60913: Introducing jemalloc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 /tests/test
 /tests/gtest/
 faiss/python/swigfaiss_avx2.swig
+/build/
+/.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ if(FAISS_ENABLE_GPU)
   enable_language(CUDA)
 endif()
 
+add_subdirectory(jemalloc_faiss)
+
 add_subdirectory(faiss)
 
 if(FAISS_ENABLE_GPU)

--- a/c_api/CMakeLists.txt
+++ b/c_api/CMakeLists.txt
@@ -26,6 +26,7 @@ set(FAISS_C_SRC
   IndexBinary_c.cpp
   IndexScalarQuantizer_c.cpp
   MetaIndexes_c.cpp
+  jemalloc_stat_c.cpp
   clone_index_c.cpp
   error_impl.cpp
   index_factory_c.cpp
@@ -35,7 +36,11 @@ set(FAISS_C_SRC
   utils/distances_c.cpp
 )
 add_library(faiss_c ${FAISS_C_SRC})
-target_link_libraries(faiss_c PRIVATE faiss)
+
+target_include_directories(faiss_c PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../jemalloc_faiss/install/include>)
+
+target_link_libraries(faiss_c PRIVATE jemalloc_faiss faiss)
 install(TARGETS faiss_c
   EXPORT faiss-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/c_api/jemalloc_conf.h
+++ b/c_api/jemalloc_conf.h
@@ -1,0 +1,36 @@
+//  Copyright 2024-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+#ifndef JEMALLOC_CONF_H
+#define JEMALLOC_CONF_H
+
+#include <jemalloc/jemalloc_faiss.h>
+/* jemalloc checks for this symbol, and it's contents for the config to use. */
+const char* malloc_conf =
+#ifndef __APPLE__
+        /* Enable background worker thread for asynchronous purging.
+        * Background threads are non-functional in jemalloc 5.1.0 on macOS due to
+        * implementation discrepancies between the background threads and mutexes.
+        * https://github.com/jemalloc/jemalloc/issues/1433
+        */
+        "background_thread:true,"
+#endif
+        /* Use 4 arenas, instead of the default based on number of CPUs.
+        Helps to minimize heap fragmentation.
+        https://github.com/jemalloc/jemalloc/blob/dev/TUNING.md
+        */
+        "narenas:4,"
+#ifdef __linux__
+        /* Start with profiling enabled but inactive; this allows us to
+        turn it on/off at runtime. */
+        "prof:true,prof_active:false,"
+#endif
+        /* abort immediately on illegal options, just for sanity */
+        "abort_conf:true";
+
+#endif /* JEMALLOC_CONF_H */

--- a/c_api/jemalloc_stat.h
+++ b/c_api/jemalloc_stat.h
@@ -1,0 +1,24 @@
+//  Copyright 2024-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+#ifndef JEMALLOC_STAT_H
+#define JEMALLOC_STAT_H
+
+#include <stddef.h>
+#include <jemalloc/jemalloc_faiss.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+    size_t jm_allocated();
+    size_t jm_resident();
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* JEMALLOC_STAT_H */

--- a/c_api/jemalloc_stat_c.cpp
+++ b/c_api/jemalloc_stat_c.cpp
@@ -1,0 +1,41 @@
+//  Copyright 2024-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+#include "jemalloc_stat.h"
+
+// Helper function for calling jemalloc epoch.
+// jemalloc stats are not updated until the caller requests a synchronisation,
+// which is done by the epoch call.
+static void callJemallocEpoch() {
+    size_t epoch = 1;
+    size_t sz = sizeof(epoch);
+    // The return of epoch is the current epoch, which we don't make use of
+    mallctl("epoch", &epoch, &sz, &epoch, sz);
+}
+
+size_t jm_allocated() {
+    // call mallctl defined in jemalloc
+    // first refresh the value of the stats
+    callJemallocEpoch();
+    // now get the stats
+    size_t allocated, sz;
+    sz = sizeof(size_t);
+    mallctl("stats.allocated", &allocated, &sz, NULL, 0);
+    return allocated;
+}
+
+size_t jm_resident() {
+    // call mallctl defined in jemalloc
+    // first refresh the value of the stats
+    callJemallocEpoch();
+    // now get the stats
+    size_t resident, sz;
+    sz = sizeof(size_t);
+    mallctl("stats.resident", &resident, &sz, NULL, 0);
+    return resident;
+}

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -274,6 +274,9 @@ endif()
 target_compile_definitions(faiss PRIVATE FINTEGER=int)
 target_compile_definitions(faiss_avx2 PRIVATE FINTEGER=int)
 
+target_link_libraries(faiss PRIVATE jemalloc_faiss)
+target_link_libraries(faiss_avx2 PRIVATE jemalloc_faiss)
+
 find_package(OpenMP REQUIRED)
 target_link_libraries(faiss PRIVATE OpenMP::OpenMP_CXX)
 target_link_libraries(faiss_avx2 PRIVATE OpenMP::OpenMP_CXX)

--- a/jemalloc_faiss/CMakeLists.txt
+++ b/jemalloc_faiss/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Downloads the declared version of libjemalloc source code and builds it.
+
+project(jemalloc_faiss)
+
+include(ExternalProject)
+
+SET (_target_name "jemalloc_faiss")
+
+SET (_external_target_name "jemalloc_faiss_external")
+
+SET (_build_script "${CMAKE_CURRENT_SOURCE_DIR}/jemalloc_unix.sh")
+
+SET (_jemalloc_src_location "${CMAKE_CURRENT_BINARY_DIR}/src/${_external_target_name}")
+
+SET (_jemalloc_install_location "${CMAKE_CURRENT_BINARY_DIR}/install")
+
+ExternalProject_Add(${_external_target_name}
+  GIT_REPOSITORY        https://github.com/jemalloc/jemalloc
+  GIT_TAG               5.3.0
+  PREFIX                "${CMAKE_CURRENT_BINARY_DIR}"
+  CONFIGURE_COMMAND     ""
+  BUILD_COMMAND         "${_build_script}" ${_jemalloc_src_location} ${_jemalloc_install_location}
+  INSTALL_COMMAND       ""
+)
+
+set (_jemalloc_include ${_jemalloc_install_location}/include)
+set (_jemalloc_lib ${_jemalloc_install_location}/lib)
+
+add_library(${_target_name} SHARED IMPORTED GLOBAL)
+set_target_properties(${_target_name} PROPERTIES IMPORTED_LOCATION ${_jemalloc_lib}/libjemalloc_faiss.so)
+
+install(FILES
+  ${_jemalloc_lib}/libjemalloc_faiss.so
+  ${_jemalloc_lib}/libjemalloc_faiss.so.2
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(DIRECTORY
+  ${_jemalloc_include}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/jemalloc_faiss/jemalloc_unix.sh
+++ b/jemalloc_faiss/jemalloc_unix.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+SRC_DIR=$1
+INSTALL_DIR=$2
+
+configure_args="--prefix=${INSTALL_DIR} --with-install-suffix=_faiss"
+
+# Profiling only supported on non-Darwin.
+if [ $(uname -s) != "Darwin" ]; then
+    configure_args+=" --enable-prof"
+fi
+
+# Change directory to the source directory
+cd "${SRC_DIR}"
+
+./autogen.sh ${configure_args} >/dev/null
+make -j8 build_lib_shared >/dev/null
+make install_lib_shared install_include install_bin >/dev/null


### PR DESCRIPTION
- Added a cmake options for building Faiss
    - `-DFAISS_ENABLE_JEMALLOC=ON` will prefix all instances of glibc's `malloc`/`free` and 
       family with `je_`, essentially using `je_malloc` universally. It must be ensured that 
      `jemalloc` is built with `prefix=je_`. If the following cmake variables are defined, it 
       will use jemalloc library and header from those directories, and if not, it will use 
       find_package to find jemalloc instead
        - `JEMALLOC_LIBRARIES` has the path to the jemalloc library.
        - `JEMALLOC_INCLUDE_DIR` has the path to the jemalloc header. 
- Export a API that will estimate and return the number of bytes in use by the memory allocator's heap (configured to be either jemalloc or malloc) at runtime.
- Experimental tuning of jemalloc 
- Added /build/ and /.vscode/ in the .gitignore
