### PR TITLE
MB-59575: Refactor member variables alignment of IndexFlatCodes

### DIFF
--- a/faiss/IndexFlatCodes.h
+++ b/faiss/IndexFlatCodes.h
@@ -24,9 +24,9 @@ struct IndexFlatCodes : Index {
 
     /// encoded dataset, size ntotal * code_size
     std::vector<uint8_t> codes;
-    uint8_t* codes_ptr;
     bool mmaped; // true if codes_ptr is pointing to a mmaped region
     size_t mmaped_size;
+    uint8_t* codes_ptr;
 
     IndexFlatCodes();
 


### PR DESCRIPTION
- moving the codes_ptr down below so that we skip compiler optimization for that pointer member variable