### PR TITLE
MB-59575: Revert memcpy optimizations for flat indexes

### DIFF
--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -169,10 +169,6 @@ FlatCodesDistanceComputer* IndexFlat::get_FlatCodesDistanceComputer() const {
 }
 
 void IndexFlat::reconstruct(idx_t key, float* recons) const {
-    if (mmaped) {
-        memcpy(recons, &(codes_ptr[key * code_size]), code_size);
-        return;
-    }
     memcpy(recons, &(codes[key * code_size]), code_size);
 }
 

--- a/faiss/IndexFlat.h
+++ b/faiss/IndexFlat.h
@@ -54,15 +54,9 @@ struct IndexFlat : IndexFlatCodes {
 
     // get pointer to the floating point data
     float* get_xb() {
-        if (mmaped) {
-            return (float*)(codes_ptr);
-        }
         return (float*)codes.data();
     }
     const float* get_xb() const {
-        if (mmaped) {
-            return (const float*)(codes_ptr);
-        }
         return (const float*)codes.data();
     }
 

--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -18,20 +18,9 @@ namespace faiss {
 IndexFlatCodes::IndexFlatCodes(size_t code_size, idx_t d, MetricType metric)
         : Index(d, metric), code_size(code_size) {}
 
-IndexFlatCodes::IndexFlatCodes() :
-            code_size(0),
-            mmaped_size(0),
-            mmaped(false),
-            codes_ptr(nullptr) {}
+IndexFlatCodes::IndexFlatCodes() : code_size(0) {}
 
-IndexFlatCodes::~IndexFlatCodes() {
-    // setting the pointer to nullptr so that the mmap'd region is zero counted
-    // from faiss side and safe to be free'd/GC'd etc. on calling application layer
-    // of faiss.
-    if (mmaped) {
-        codes_ptr = nullptr;
-    }
-}
+IndexFlatCodes::~IndexFlatCodes() {}
 
 void IndexFlatCodes::add(idx_t n, const float* x) {
     FAISS_THROW_IF_NOT(is_trained);

--- a/faiss/IndexFlatCodes.h
+++ b/faiss/IndexFlatCodes.h
@@ -24,9 +24,6 @@ struct IndexFlatCodes : Index {
 
     /// encoded dataset, size ntotal * code_size
     std::vector<uint8_t> codes;
-    bool mmaped; // true if codes_ptr is pointing to a mmaped region
-    size_t mmaped_size;
-    uint8_t* volatile codes_ptr;
 
     IndexFlatCodes();
 

--- a/faiss/IndexFlatCodes.h
+++ b/faiss/IndexFlatCodes.h
@@ -26,7 +26,7 @@ struct IndexFlatCodes : Index {
     std::vector<uint8_t> codes;
     bool mmaped; // true if codes_ptr is pointing to a mmaped region
     size_t mmaped_size;
-    uint8_t* codes_ptr;
+    uint8_t* volatile codes_ptr;
 
     IndexFlatCodes();
 

--- a/faiss/IndexFlatCodes.h
+++ b/faiss/IndexFlatCodes.h
@@ -24,9 +24,9 @@ struct IndexFlatCodes : Index {
 
     /// encoded dataset, size ntotal * code_size
     std::vector<uint8_t> codes;
-    uint8_t* codes_ptr;
     bool mmaped; // true if codes_ptr is pointing to a mmaped region
     size_t mmaped_size;
+    uint8_t* codes_ptr;
 
     IndexFlatCodes();
 

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -523,40 +523,6 @@ static IndexIVFPQ* read_ivfpq(IOReader* f, uint32_t h, int io_flags) {
 
 int read_old_fmt_hack = 0;
 
-/**
- * flat indexes which store the codes directly, can use this API instead to have a
- * pointer to the mmaped region to avoid allocation costs. works specifically with
- * BufIOReader as of now.
-**/
-void read_codes_mmaped(IOReader* f, IndexFlat* idxf) {
-    idxf->mmaped = true;
-
-    // read the size of codes data
-    size_t size;
-    READANDCHECK(&size, 1);
-    FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40));
-    size *= 4;
-
-    // size == ntotal * code_size == ntotal * d * sizeof(float) for IndexFlat
-    // NOTE: the code_size value can change for indexes with encodings like
-    // SQ, PQ although the size value will still be equal to ntotal * code_size
-    // bytes which is accessible via codes_ptr.
-    FAISS_THROW_IF_NOT(size == idxf->ntotal * idxf->code_size);
-    idxf->mmaped_size = size;
-
-    // BufIOReader is the reader which has a direct pointer to the mmaped
-    // byte array, so we can directly set the codes_ptr to the mmaped region
-    BufIOReader* reader = dynamic_cast<BufIOReader*>(f);
-    FAISS_THROW_IF_NOT_MSG(reader, "reading over mmap'd region is supported only with BufIOReader");
-    FAISS_THROW_IF_NOT_MSG(reader->buf, "reader buffer is null");
-
-    idxf->codes_ptr = const_cast<uint8_t*>(reader->buf);
-    // seek to the point where the codes section begins
-    idxf->codes_ptr += reader->rp;
-    // update read pointer appropriately
-    reader->rp += size;
-}
-
 Index* read_index(IOReader* f, int io_flags) {
     Index* idx = nullptr;
     uint32_t h;
@@ -573,13 +539,9 @@ Index* read_index(IOReader* f, int io_flags) {
         read_index_header(idxf, f);
         idxf->code_size = idxf->d * sizeof(float);
 
-        if (io_flags & IO_FLAG_READ_MMAP) {
-            read_codes_mmaped(f, idxf);
-        } else {
-            READXBVECTOR(idxf->codes);
-            FAISS_THROW_IF_NOT(
-                idxf->codes.size() == idxf->ntotal * idxf->code_size);
-        }
+        READXBVECTOR(idxf->codes);
+        FAISS_THROW_IF_NOT(
+            idxf->codes.size() == idxf->ntotal * idxf->code_size);
         // leak!
         idx = idxf;
     } else if (h == fourcc("IxHE") || h == fourcc("IxHe")) {


### PR DESCRIPTION
- the recent changes for optimising memcpy operations around flat indexes is giving issues when compiled with `RelWithDebInfo` (the cause is still being investigated). reverting this to stabilize the build (the perf tests don't crash with the revert). 