### PR TITLE
MB-61930: Optimize Thread Management in High Throughput Scenarios

### DIFF
--- a/faiss/IndexIDMap.cpp
+++ b/faiss/IndexIDMap.cpp
@@ -120,6 +120,8 @@ void IndexIDMapTemplate<IndexT>::search(
     }
     index->search(n, x, k, distances, labels, params);
     idx_t* li = labels;
+
+    // Dropping omp parallel for bleve
     for (idx_t i = 0; i < n * k; i++) {
         li[i] = li[i] < 0 ? li[i] : id_map[li[i]];
     }

--- a/faiss/IndexIDMap.cpp
+++ b/faiss/IndexIDMap.cpp
@@ -120,7 +120,6 @@ void IndexIDMapTemplate<IndexT>::search(
     }
     index->search(n, x, k, distances, labels, params);
     idx_t* li = labels;
-#pragma omp parallel for
     for (idx_t i = 0; i < n * k; i++) {
         li[i] = li[i] < 0 ? li[i] : id_map[li[i]];
     }

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -58,9 +58,10 @@ void IndexScalarQuantizer::search(
     FAISS_THROW_IF_NOT(
             metric_type == METRIC_L2 || metric_type == METRIC_INNER_PRODUCT);
 
-// adding an openMP guard here to spawn threads only if n > 1, where n is the number 
+// Adding an openMP guard here to spawn threads only if n > 1, where n is the number
 // of queries in the batch. If n = 1, then the search is done in a single thread.
 // This is done to avoid the overhead of spawning threads for executing sequential code.
+// This is for bleve, more in: MB-61930
 #pragma omp parallel if (n > 1)
     {
         InvertedListScanner* scanner =

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -58,6 +58,9 @@ void IndexScalarQuantizer::search(
     FAISS_THROW_IF_NOT(
             metric_type == METRIC_L2 || metric_type == METRIC_INNER_PRODUCT);
 
+// adding an openMP guard here to spawn threads only if n > 1, where n is the number 
+// of queries in the batch. If n = 1, then the search is done in a single thread.
+// This is done to avoid the overhead of spawning threads for executing sequential code.
 #pragma omp parallel if (n > 1)
     {
         InvertedListScanner* scanner =

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -58,7 +58,7 @@ void IndexScalarQuantizer::search(
     FAISS_THROW_IF_NOT(
             metric_type == METRIC_L2 || metric_type == METRIC_INNER_PRODUCT);
 
-#pragma omp parallel
+#pragma omp parallel if (n > 1)
     {
         InvertedListScanner* scanner =
                 sq.select_InvertedListScanner(metric_type, nullptr, true, sel);

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -601,6 +601,8 @@ void train_NonUniform(
             }
         }
         std::vector<float> trained_d(2);
+        // add an openMP guard here to prevent spawning threads
+        // when d = 1 (which would indicate sequential execution) 
 #pragma omp parallel for if (d > 1)
         for (int j = 0; j < d; j++) {
             train_Uniform(rs, rs_arg, n, k, xt.data() + j * n, trained_d);
@@ -1157,6 +1159,8 @@ void ScalarQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
     std::unique_ptr<SQuantizer> squant(select_quantizer());
 
     memset(codes, 0, code_size * n);
+    // add an openMP guard here to prevent spawning threads
+    // when n = 1 (which would indicate sequential execution) 
 #pragma omp parallel for if (n > 1)
     for (int64_t i = 0; i < n; i++)
         squant->encode_vector(x + i * d, codes + i * code_size);
@@ -1165,6 +1169,8 @@ void ScalarQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
 void ScalarQuantizer::decode(const uint8_t* codes, float* x, size_t n) const {
     std::unique_ptr<SQuantizer> squant(select_quantizer());
 
+    // add an openMP guard here to prevent spawning threads
+    // when n = 1 (which would indicate sequential execution) 
 #pragma omp parallel for if (n > 1)
     for (int64_t i = 0; i < n; i++)
         squant->decode_vector(codes + i * code_size, x + i * d);

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -601,8 +601,10 @@ void train_NonUniform(
             }
         }
         std::vector<float> trained_d(2);
-        // add an openMP guard here to prevent spawning threads
-        // when d = 1 (which would indicate sequential execution) 
+
+// Add an openMP guard here to prevent spawning threads
+// when d = 1 (which would indicate sequential execution).
+// This is for bleve, more in MB-61930.
 #pragma omp parallel for if (d > 1)
         for (int j = 0; j < d; j++) {
             train_Uniform(rs, rs_arg, n, k, xt.data() + j * n, trained_d);
@@ -1159,8 +1161,10 @@ void ScalarQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
     std::unique_ptr<SQuantizer> squant(select_quantizer());
 
     memset(codes, 0, code_size * n);
-    // add an openMP guard here to prevent spawning threads
-    // when n = 1 (which would indicate sequential execution) 
+
+// Add an openMP guard here to prevent spawning threads
+// when n = 1 (which would indicate sequential execution).
+// This is for bleve, more in MB-61930.
 #pragma omp parallel for if (n > 1)
     for (int64_t i = 0; i < n; i++)
         squant->encode_vector(x + i * d, codes + i * code_size);
@@ -1169,8 +1173,9 @@ void ScalarQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
 void ScalarQuantizer::decode(const uint8_t* codes, float* x, size_t n) const {
     std::unique_ptr<SQuantizer> squant(select_quantizer());
 
-    // add an openMP guard here to prevent spawning threads
-    // when n = 1 (which would indicate sequential execution) 
+// Add an openMP guard here to prevent spawning threads
+// when n = 1 (which would indicate sequential execution).
+// This is for bleve, more in MB-61930.
 #pragma omp parallel for if (n > 1)
     for (int64_t i = 0; i < n; i++)
         squant->decode_vector(codes + i * code_size, x + i * d);

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -601,7 +601,7 @@ void train_NonUniform(
             }
         }
         std::vector<float> trained_d(2);
-#pragma omp parallel for
+#pragma omp parallel for if (d > 1)
         for (int j = 0; j < d; j++) {
             train_Uniform(rs, rs_arg, n, k, xt.data() + j * n, trained_d);
             vmin[j] = trained_d[0];
@@ -1157,7 +1157,7 @@ void ScalarQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
     std::unique_ptr<SQuantizer> squant(select_quantizer());
 
     memset(codes, 0, code_size * n);
-#pragma omp parallel for
+#pragma omp parallel for if (n > 1)
     for (int64_t i = 0; i < n; i++)
         squant->encode_vector(x + i * d, codes + i * code_size);
 }
@@ -1165,7 +1165,7 @@ void ScalarQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
 void ScalarQuantizer::decode(const uint8_t* codes, float* x, size_t n) const {
     std::unique_ptr<SQuantizer> squant(select_quantizer());
 
-#pragma omp parallel for
+#pragma omp parallel for if (n > 1)
     for (int64_t i = 0; i < n; i++)
         squant->decode_vector(codes + i * code_size, x + i * d);
 }


### PR DESCRIPTION
- Add guards to prevent unnecessary thread spawning by OpenMP in sequential code sections.
- De-parallelize a for loop that was creating excessive threads in high query throughput scenarios. The overhead of thread management in this context outweighed the minor performance boost from parallelization, as the loop primarily populates an array. 