### PR TITLE
MB-61093 Add method to compute distance from codes for IVF index

### DIFF
--- a/c_api/IndexIVF_c_ex.cpp
+++ b/c_api/IndexIVF_c_ex.cpp
@@ -67,3 +67,18 @@ int faiss_IndexIVF_search_preassigned_with_params(
     }
     CATCH_AND_HANDLE
 }
+
+int faiss_IndexIVF_compute_distance_to_codes_for_list(
+        FaissIndexIVF* index,
+        idx_t list_no,
+        const float* x,
+        idx_t n,
+        const uint8_t* codes,
+        float* dists) {
+    try {
+        reinterpret_cast<IndexIVF*>(index)->compute_distance_to_codes_for_list(
+		list_no, x, n, codes, dists);
+        return 0;
+    }
+    CATCH_AND_HANDLE
+}

--- a/c_api/IndexIVF_c_ex.h
+++ b/c_api/IndexIVF_c_ex.h
@@ -67,14 +67,27 @@ int faiss_IndexIVF_search_preassigned_with_params(
         int store_pairs,
         const FaissSearchParametersIVF* params);
 
+    /** Given a query vector x, compute distance to provided codes
+     * for the input list_no. This is a special purpose method
+     * to be used as a flat distance computer for an inverted
+     * list where codes are provided externally. This allows to
+     * use the quantizer while computing distance for the quantized
+     * codes.
+     *
+     * @param list_no list number for inverted list
+     * @param x - input query vector
+     * @param n - number of codes
+     * @param codes - input codes
+     * @param dists - output computed distances
+     */
 
-int faiss_Search_closest_eligible_centroids(
-        FaissIndex* index,
-        float* query,
-         FaissSearchParameters* params,
-        float* centroid_distances,
-        idx_t* centroid_ids
-);
+int faiss_IndexIVF_compute_distance_to_codes_for_list(
+        FaissIndexIVF* index,
+        idx_t list_no,
+        const float* x,
+        idx_t n,
+        const uint8_t* codes,
+        float* dists);
 
 
 #ifdef __cplusplus

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -410,6 +410,27 @@ struct IndexIVF : Index, IndexIVFInterface {
             idx_t a1,
             idx_t a2) const;
 
+    /** Given a query vector x, compute distance to provided codes
+     * for the input list_no. This is a special purpose method
+     * to be used as a flat distance computer for an inverted
+     * list where codes are provided externally. This allows to
+     * use the quantizer while computing distance for the quantized
+     * codes.
+     *
+     * @param list_no list number for inverted list
+     * @param x - input query vector
+     * @param n - number of codes
+     * @param codes - input codes
+     * @param dists - output computed distances
+     */
+
+    virtual void compute_distance_to_codes_for_list(
+        const idx_t list_no,
+        const float* x,
+        idx_t n,
+        const uint8_t* codes,
+        float* dists) const {};
+
     ~IndexIVF() override;
 
     size_t get_list_size(size_t list_no) const {

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -282,4 +282,28 @@ void IndexIVFScalarQuantizer::reconstruct_from_offset(
     }
 }
 
+void IndexIVFScalarQuantizer::compute_distance_to_codes_for_list(const idx_t list_no,
+        const float* x,
+	idx_t n,
+	const uint8_t* codes,
+	float* dists) const {
+
+    ScalarQuantizer::SQDistanceComputer* dc =
+            sq.get_distance_computer(metric_type);
+    dc->code_size = sq.code_size;
+
+    if (by_residual) {
+        // shift of x_in wrt centroid
+	std::vector<float> tmp(d);
+        quantizer->compute_residual(x, tmp.data(), list_no);
+        dc->set_query(tmp.data());
+    } else {
+        dc->set_query(x);
+    }
+
+    dc->distance_to_codes(n, codes, dists);
+
+    return;
+}
+
 } // namespace faiss

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -103,6 +103,14 @@ struct IndexIVFScalarQuantizer : IndexIVF {
 
     /* standalone codec interface */
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+
+    void compute_distance_to_codes_for_list(
+        const idx_t list_no,
+        const float* x,
+        idx_t n,
+        const uint8_t* codes,
+        float* dists) const override;
+
 };
 
 } // namespace faiss

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -1873,4 +1873,12 @@ InvertedListScanner* ScalarQuantizer::select_InvertedListScanner(
     }
 }
 
+void SQDistanceComputer::distance_to_codes(idx_t n, const uint8_t* codes, float* dists) {
+    for (idx_t i = 0; i < n; i++) {
+        const uint8_t* code = codes + i * code_size;
+        dists[i] = query_to_code(code);
+    }
+    return;
+}
+
 } // namespace faiss

--- a/faiss/impl/ScalarQuantizer.h
+++ b/faiss/impl/ScalarQuantizer.h
@@ -104,6 +104,8 @@ struct ScalarQuantizer : Quantizer {
         float distance_to_code(const uint8_t* code) final {
             return query_to_code(code);
         }
+
+        void distance_to_codes(idx_t n, const uint8_t* codes, float* dists);
     };
 
     SQDistanceComputer* get_distance_computer(


### PR DESCRIPTION
Given a query vector x, compute distance to provided codes for the input list_no. This is a special purpose method to be used as a flat distance computer for an inverted list where codes are provided externally. This allows to use the quantizer while computing distance for the quantized codes.