### PR TITLE
MB-61093 Fix memory leak for SQDistanceComputer

### DIFF
--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -289,8 +289,9 @@ void IndexIVFScalarQuantizer::compute_distance_to_codes_for_list(
         const uint8_t* codes,
         float* dists) const {
 
-    ScalarQuantizer::SQDistanceComputer* dc =
-            sq.get_distance_computer(metric_type);
+    std::unique_ptr<ScalarQuantizer::SQDistanceComputer> dc(
+        sq.get_distance_computer(metric_type));
+
     dc->code_size = sq.code_size;
 
     if (by_residual) {


### PR DESCRIPTION
* Use unique_ptr to manage SQDistanceComputer lifecycle.