### PR TITLE
MB-65473: Refactor and Optimize Pre-Filtered Vector Search

### DIFF
--- a/c_api/IndexIVF_c_ex.cpp
+++ b/c_api/IndexIVF_c_ex.cpp
@@ -52,6 +52,13 @@ int faiss_Search_closest_eligible_centroids(
     CATCH_AND_HANDLE
 }
 
+idx_t faiss_get_list_for_key(FaissIndexIVF* index, idx_t key) {
+    try {
+        return reinterpret_cast<IndexIVF*>(index)->get_list_for_key(key);
+    }
+    CATCH_AND_HANDLE
+}
+
 int faiss_IndexIVF_search_preassigned_with_params(
         const FaissIndexIVF* index,
         idx_t n,

--- a/c_api/IndexIVF_c_ex.cpp
+++ b/c_api/IndexIVF_c_ex.cpp
@@ -52,7 +52,9 @@ int faiss_Search_closest_eligible_centroids(
     CATCH_AND_HANDLE
 }
 
-idx_t faiss_get_list_for_key(FaissIndexIVF* index, idx_t key) {
+idx_t faiss_get_list_for_key(
+        FaissIndexIVF* index, 
+        idx_t key) {
     try {
         return reinterpret_cast<IndexIVF*>(index)->get_list_for_key(key);
     }

--- a/c_api/IndexIVF_c_ex.h
+++ b/c_api/IndexIVF_c_ex.h
@@ -91,7 +91,17 @@ int faiss_IndexIVF_compute_distance_to_codes_for_list(
         const uint8_t* codes,
         float* dists);
 
-idx_t faiss_get_list_for_key(FaissIndexIVF* index, idx_t key);
+/* 
+    Given a query vector ID `key`, return the list number  
+    where the vector is stored. In the context of an IVF index,  
+    this corresponds to the cluster that contains the vector.  
+
+    @param key - vector ID  
+*/
+
+idx_t faiss_get_list_for_key(
+        FaissIndexIVF* index, 
+        idx_t key);
 
 #ifdef __cplusplus
 }

--- a/c_api/IndexIVF_c_ex.h
+++ b/c_api/IndexIVF_c_ex.h
@@ -91,6 +91,8 @@ int faiss_IndexIVF_compute_distance_to_codes_for_list(
         const uint8_t* codes,
         float* dists);
 
+idx_t faiss_get_list_for_key(FaissIndexIVF* index, idx_t key);
+
 #ifdef __cplusplus
 }
 #endif

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -922,6 +922,11 @@ void IndexIVF::reconstruct(idx_t key, float* recons) const {
     reconstruct_from_offset(lo_listno(lo), lo_offset(lo), recons);
 }
 
+idx_t IndexIVF::get_list_for_key(idx_t key) {
+    idx_t lo = direct_map.get(key);
+    return lo_listno(lo);
+}
+
 void IndexIVF::reconstruct_n(idx_t i0, idx_t ni, float* recons) const {
     FAISS_THROW_IF_NOT(ni == 0 || (i0 >= 0 && i0 + ni <= ntotal));
 

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -343,6 +343,8 @@ struct IndexIVF : Index, IndexIVFInterface {
      */
     void reconstruct_n(idx_t i0, idx_t ni, float* recons) const override;
 
+    idx_t get_list_for_key(idx_t key);
+
     /** Similar to search, but also reconstructs the stored vectors (or an
      * approximation in the case of lossy coding) for the search results.
      *


### PR DESCRIPTION
Add API for IndexIVF, that given a query vector ID `key`, will
return the list number   where the vector is stored.

In the context of an IVF index,  this corresponds to the cluster
that contains the vector.  