### PR TITLE
MB-62985 - Adding BQ vector-related utils.

### DIFF
--- a/c_api/CMakeLists.txt
+++ b/c_api/CMakeLists.txt
@@ -24,6 +24,7 @@ set(FAISS_C_SRC
   Index_c.cpp
   Index_c_ex.cpp
   IndexBinary_c.cpp
+  IndexBinaryIVF_c.cpp
   IndexScalarQuantizer_c.cpp
   MetaIndexes_c.cpp
   clone_index_c.cpp

--- a/c_api/IndexBinaryIVF_c.cpp
+++ b/c_api/IndexBinaryIVF_c.cpp
@@ -9,4 +9,63 @@ int faiss_IndexBinaryIVF_set_direct_map(
     }
     CATCH_AND_HANDLE
 }
+
+int faiss_get_lists_for_keys_binary(
+        FaissIndexBinaryIVF* index,
+        idx_t* keys,
+        size_t n_keys,
+        idx_t* lists) {
+    try {
+        reinterpret_cast<faiss::IndexBinaryIVF*>(index)->get_lists_for_keys(
+                keys, n_keys, lists);
+    }
+    CATCH_AND_HANDLE
+}
+
+int faiss_Search_closest_eligible_centroids_binary(
+        FaissIndexBinaryIVF* index,
+        idx_t n,
+        const uint8_t* query,
+        idx_t k,
+        int32_t* centroid_distances,
+        idx_t* centroid_ids,
+        const FaissSearchParameters* params) {
+    try {
+        faiss::IndexBinaryIVF* index_bivf = reinterpret_cast<IndexBinaryIVF*>(index);
+        assert(index_bivf);
+
+        index_bivf->quantizer->search(
+                n,
+                query,
+                k,
+                centroid_distances,
+                centroid_ids,
+                reinterpret_cast<const faiss::SearchParameters*>(params));
+    }
+    CATCH_AND_HANDLE
+}
+
+int faiss_IndexBinaryIVF_search_preassigned_with_params(
+        const FaissIndexBinaryIVF* index,
+        idx_t n,
+        const uint8_t* x,
+        idx_t k,
+        const idx_t* assign,
+        const int32_t* centroid_dis,
+        int32_t* distances,
+        idx_t* labels,
+        int store_pairs,
+        const FaissSearchParametersIVF* params) {
+    try {
+        faiss::IndexBinaryIVF* index_bivf = reinterpret_cast<IndexBinaryIVF*>(index);
+        assert(index_bivf);
+
+        index_bivf->search_preassigned(n, x, k, assign, centroid_dis, distances, 
+        labels, store_pairs, reinterpret_cast<const faiss::SearchParameters*>(params));
+    }
+    CATCH_AND_HANDLE
+}
+
+
+
 }

--- a/c_api/IndexBinaryIVF_c.cpp
+++ b/c_api/IndexBinaryIVF_c.cpp
@@ -1,0 +1,12 @@
+extern "C" {
+
+int faiss_IndexBinaryIVF_set_direct_map(
+        FaissIndexBinaryIVF* index,
+        int direct_map_type) {
+    try {
+        reinterpret_cast<faiss::IndexBinaryIVF*>(index)->set_direct_map_type(
+                static_cast<faiss::DirectMap::Type>(direct_map_type));
+    }
+    CATCH_AND_HANDLE
+}
+}

--- a/c_api/IndexBinaryIVF_c.cpp
+++ b/c_api/IndexBinaryIVF_c.cpp
@@ -1,11 +1,20 @@
+#include "IndexBinaryIVF_c.h"
+#include <faiss/IndexBinaryIVF.h>
+#include "macros_impl.h"
+
+using faiss::IndexBinaryIVF;
+
+DEFINE_GETTER_PERMISSIVE(IndexBinaryIVF, FaissIndexBinaryPtr, quantizer)
+
 extern "C" {
 
 int faiss_IndexBinaryIVF_set_direct_map(
         FaissIndexBinaryIVF* index,
         int direct_map_type) {
     try {
-        reinterpret_cast<faiss::IndexBinaryIVF*>(index)->set_direct_map_type(
+        reinterpret_cast<IndexBinaryIVF*>(index)->set_direct_map_type(
                 static_cast<faiss::DirectMap::Type>(direct_map_type));
+        return 0;
     }
     CATCH_AND_HANDLE
 }
@@ -16,8 +25,9 @@ int faiss_get_lists_for_keys_binary(
         size_t n_keys,
         idx_t* lists) {
     try {
-        reinterpret_cast<faiss::IndexBinaryIVF*>(index)->get_lists_for_keys(
+        reinterpret_cast<IndexBinaryIVF*>(index)->get_lists_for_keys(
                 keys, n_keys, lists);
+        return 0;
     }
     CATCH_AND_HANDLE
 }
@@ -31,16 +41,23 @@ int faiss_Search_closest_eligible_centroids_binary(
         idx_t* centroid_ids,
         const FaissSearchParameters* params) {
     try {
-        faiss::IndexBinaryIVF* index_bivf = reinterpret_cast<IndexBinaryIVF*>(index);
-        assert(index_bivf);
-
-        index_bivf->quantizer->search(
+        auto idx = reinterpret_cast<IndexBinaryIVF*>(index);
+        idx->quantizer->search(
                 n,
                 query,
                 k,
                 centroid_distances,
                 centroid_ids,
                 reinterpret_cast<const faiss::SearchParameters*>(params));
+
+        return 0;
+    }
+    CATCH_AND_HANDLE
+}
+
+int faiss_IndexBinaryIVF_set_is_trained(FaissIndexBinaryIVF* index, int is_trained) {
+    try {
+        reinterpret_cast<faiss::IndexBinaryIVF*>(index)->is_trained = static_cast<bool>(is_trained);
     }
     CATCH_AND_HANDLE
 }
@@ -57,15 +74,14 @@ int faiss_IndexBinaryIVF_search_preassigned_with_params(
         int store_pairs,
         const FaissSearchParametersIVF* params) {
     try {
-        faiss::IndexBinaryIVF* index_bivf = reinterpret_cast<IndexBinaryIVF*>(index);
-        assert(index_bivf);
-
-        index_bivf->search_preassigned(n, x, k, assign, centroid_dis, distances, 
-        labels, store_pairs, reinterpret_cast<const faiss::SearchParameters*>(params));
+        auto idx = reinterpret_cast<const IndexBinaryIVF*>(index);
+        idx->search_preassigned(
+                n, x, k, assign, centroid_dis, distances, labels,
+                static_cast<bool>(store_pairs),
+                reinterpret_cast<const faiss::IVFSearchParameters*>(params));
+        return 0;
     }
     CATCH_AND_HANDLE
 }
 
-
-
-}
+} // extern "C"

--- a/c_api/IndexBinaryIVF_c.h
+++ b/c_api/IndexBinaryIVF_c.h
@@ -1,0 +1,21 @@
+#ifndef FAISS_INDEX_BINARY_IVF_C_H
+#define FAISS_INDEX_BINARY_IVF_C_H
+
+#include "Index_c.h"
+#include "faiss_c.h"
+#include "macros_impl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int faiss_IndexBinaryIVF_set_direct_map(
+        FaissIndexBinaryIVF* index,
+        int direct_map_type);
+
+DEFINE_GETTER_PERMISSIVE(IndexBinaryIVF, FaissIndexBinary*, quantizer);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c_api/IndexBinaryIVF_c.h
+++ b/c_api/IndexBinaryIVF_c.h
@@ -2,12 +2,17 @@
 #define FAISS_INDEX_BINARY_IVF_C_H
 
 #include "Index_c.h"
+#include "IndexBinary_c.h"
+#include "IndexIVF_c.h"
 #include "faiss_c.h"
-#include "macros_impl.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nlist)
+
+FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nprobe)
 
 int faiss_IndexBinaryIVF_set_direct_map(
         FaissIndexBinaryIVF* index,
@@ -17,8 +22,7 @@ int faiss_get_lists_for_keys_binary(
         FaissIndexBinaryIVF* index,
         idx_t* keys,
         size_t n_keys,
-        idx_t* lists) ; 
-
+        idx_t* lists);
 
 int faiss_Search_closest_eligible_centroids_binary(
         FaissIndexBinaryIVF* index,
@@ -28,6 +32,8 @@ int faiss_Search_closest_eligible_centroids_binary(
         int32_t* centroid_distances,
         idx_t* centroid_ids,
         const FaissSearchParameters* params);
+
+int faiss_IndexBinaryIVF_set_is_trained(FaissIndexBinaryIVF* index, int is_trained);
 
 int faiss_IndexBinaryIVF_search_preassigned_with_params(
         const FaissIndexBinaryIVF* index,
@@ -41,7 +47,9 @@ int faiss_IndexBinaryIVF_search_preassigned_with_params(
         int store_pairs,
         const FaissSearchParametersIVF* params);
 
-DEFINE_GETTER_PERMISSIVE(IndexBinaryIVF, FaissIndexBinary*, quantizer);
+typedef FaissIndexBinary* FaissIndexBinaryPtr;
+FaissIndexBinaryPtr faiss_IndexBinaryIVF_quantizer(const FaissIndexBinaryIVF* index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c_api/IndexBinaryIVF_c.h
+++ b/c_api/IndexBinaryIVF_c.h
@@ -13,6 +13,34 @@ int faiss_IndexBinaryIVF_set_direct_map(
         FaissIndexBinaryIVF* index,
         int direct_map_type);
 
+int faiss_get_lists_for_keys_binary(
+        FaissIndexBinaryIVF* index,
+        idx_t* keys,
+        size_t n_keys,
+        idx_t* lists) ; 
+
+
+int faiss_Search_closest_eligible_centroids_binary(
+        FaissIndexBinaryIVF* index,
+        idx_t n,
+        const uint8_t* query,
+        idx_t k,
+        int32_t* centroid_distances,
+        idx_t* centroid_ids,
+        const FaissSearchParameters* params);
+
+int faiss_IndexBinaryIVF_search_preassigned_with_params(
+        const FaissIndexBinaryIVF* index,
+        idx_t n,
+        const uint8_t* x,
+        idx_t k,
+        const idx_t* assign,
+        const int32_t* centroid_dis,
+        int32_t* distances,
+        idx_t* labels,
+        int store_pairs,
+        const FaissSearchParametersIVF* params);
+
 DEFINE_GETTER_PERMISSIVE(IndexBinaryIVF, FaissIndexBinary*, quantizer);
 #ifdef __cplusplus
 }

--- a/c_api/IndexBinary_c.cpp
+++ b/c_api/IndexBinary_c.cpp
@@ -29,6 +29,11 @@ DEFINE_GETTER(IndexBinary, FaissMetricType, metric_type)
 DEFINE_GETTER(IndexBinary, int, verbose);
 DEFINE_SETTER(IndexBinary, int, verbose);
 
+DEFINE_GETTER(IndexBinaryIVF, size_t, nprobe);
+DEFINE_SETTER(IndexBinaryIVF, size_t, nprobe);
+
+DEFINE_INDEXBINARY_DOWNCAST(IndexBinaryIVF)
+
 int faiss_IndexBinaryIVF_set_direct_map(
         FaissIndexBinaryIVF* index,
         int direct_map_type) {

--- a/c_api/IndexBinary_c.cpp
+++ b/c_api/IndexBinary_c.cpp
@@ -9,10 +9,10 @@
 
 #include "IndexBinary_c.h"
 #include <faiss/IndexBinary.h>
-#include "macros_impl.h"
-#include "IndexIVF_c_ex.h"
-#include <faiss/IndexIVF.h>
 #include <faiss/IndexBinaryIVF.h>
+#include <faiss/IndexIVF.h>
+#include "IndexIVF_c_ex.h"
+#include "macros_impl.h"
 
 extern "C" {
 
@@ -182,13 +182,16 @@ int faiss_IndexBinary_reconstruct_n(
     CATCH_AND_HANDLE
 }
 
-FaissIndexBinary* faiss_IndexBinaryIVF_quantizer(const FaissIndexBinaryIVF* index) {
+FaissIndexBinary* faiss_IndexBinaryIVF_quantizer(
+        const FaissIndexBinaryIVF* index) {
     return reinterpret_cast<FaissIndexBinary*>(
-        reinterpret_cast<const faiss::IndexBinaryIVF*>(index)->quantizer);
+            reinterpret_cast<const faiss::IndexBinaryIVF*>(index)->quantizer);
 }
 
-void faiss_IndexBinaryIVF_set_quantizer(FaissIndexBinaryIVF* index, FaissIndexBinary* quantizer) {
-    reinterpret_cast<faiss::IndexBinaryIVF*>(index)->quantizer = 
-        reinterpret_cast<faiss::IndexBinary*>(quantizer);
+void faiss_IndexBinaryIVF_set_quantizer(
+        FaissIndexBinaryIVF* index,
+        FaissIndexBinary* quantizer) {
+    reinterpret_cast<faiss::IndexBinaryIVF*>(index)->quantizer =
+            reinterpret_cast<faiss::IndexBinary*>(quantizer);
 }
 }

--- a/c_api/IndexBinary_c.cpp
+++ b/c_api/IndexBinary_c.cpp
@@ -21,6 +21,7 @@ DEFINE_DESTRUCTOR(IndexBinary)
 DEFINE_GETTER(IndexBinary, int, d)
 
 DEFINE_GETTER(IndexBinary, int, is_trained)
+DEFINE_SETTER(IndexBinary, int, is_trained)
 
 DEFINE_GETTER(IndexBinary, idx_t, ntotal)
 
@@ -179,5 +180,15 @@ int faiss_IndexBinary_reconstruct_n(
                 i0, ni, recons);
     }
     CATCH_AND_HANDLE
+}
+
+FaissIndexBinary* faiss_IndexBinaryIVF_quantizer(const FaissIndexBinaryIVF* index) {
+    return reinterpret_cast<FaissIndexBinary*>(
+        reinterpret_cast<const faiss::IndexBinaryIVF*>(index)->quantizer);
+}
+
+void faiss_IndexBinaryIVF_set_quantizer(FaissIndexBinaryIVF* index, FaissIndexBinary* quantizer) {
+    reinterpret_cast<faiss::IndexBinaryIVF*>(index)->quantizer = 
+        reinterpret_cast<faiss::IndexBinary*>(quantizer);
 }
 }

--- a/c_api/IndexBinary_c.cpp
+++ b/c_api/IndexBinary_c.cpp
@@ -32,6 +32,9 @@ DEFINE_SETTER(IndexBinary, int, verbose);
 DEFINE_GETTER(IndexBinaryIVF, size_t, nprobe);
 DEFINE_SETTER(IndexBinaryIVF, size_t, nprobe);
 
+DEFINE_GETTER(IndexBinaryIVF, size_t, nlist);
+DEFINE_SETTER(IndexBinaryIVF, size_t, nlist);
+
 DEFINE_INDEXBINARY_DOWNCAST(IndexBinaryIVF)
 
 int faiss_IndexBinaryIVF_set_direct_map(
@@ -82,6 +85,26 @@ int faiss_IndexBinary_search(
     try {
         reinterpret_cast<const faiss::IndexBinary*>(index)->search(
                 n, x, k, distances, labels);
+    }
+    CATCH_AND_HANDLE
+}
+
+int faiss_IndexBinary_search_with_params(
+        const FaissIndexBinary* index,
+        idx_t n,
+        const uint8_t* x,
+        idx_t k,
+        const FaissSearchParameters* params,
+        int32_t* distances,
+        idx_t* labels) {
+    try {
+        reinterpret_cast<const faiss::IndexBinary*>(index)->search(
+                n,
+                x,
+                k,
+                distances,
+                labels,
+                reinterpret_cast<const faiss::SearchParameters*>(params));
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/IndexBinary_c.cpp
+++ b/c_api/IndexBinary_c.cpp
@@ -38,16 +38,6 @@ DEFINE_SETTER(IndexBinaryIVF, size_t, nlist);
 
 DEFINE_INDEXBINARY_DOWNCAST(IndexBinaryIVF)
 
-int faiss_IndexBinaryIVF_set_direct_map(
-        FaissIndexBinaryIVF* index,
-        int direct_map_type) {
-    try {
-        reinterpret_cast<faiss::IndexBinaryIVF*>(index)->set_direct_map_type(
-                static_cast<faiss::DirectMap::Type>(direct_map_type));
-    }
-    CATCH_AND_HANDLE
-}
-
 int faiss_IndexBinary_train(
         FaissIndexBinary* index,
         idx_t n,
@@ -180,18 +170,5 @@ int faiss_IndexBinary_reconstruct_n(
                 i0, ni, recons);
     }
     CATCH_AND_HANDLE
-}
-
-FaissIndexBinary* faiss_IndexBinaryIVF_quantizer(
-        const FaissIndexBinaryIVF* index) {
-    return reinterpret_cast<FaissIndexBinary*>(
-            reinterpret_cast<const faiss::IndexBinaryIVF*>(index)->quantizer);
-}
-
-void faiss_IndexBinaryIVF_set_quantizer(
-        FaissIndexBinaryIVF* index,
-        FaissIndexBinary* quantizer) {
-    reinterpret_cast<faiss::IndexBinaryIVF*>(index)->quantizer =
-            reinterpret_cast<faiss::IndexBinary*>(quantizer);
 }
 }

--- a/c_api/IndexBinary_c.cpp
+++ b/c_api/IndexBinary_c.cpp
@@ -10,6 +10,9 @@
 #include "IndexBinary_c.h"
 #include <faiss/IndexBinary.h>
 #include "macros_impl.h"
+#include "IndexIVF_c_ex.h"
+#include <faiss/IndexIVF.h>
+#include <faiss/IndexBinaryIVF.h>
 
 extern "C" {
 
@@ -25,6 +28,16 @@ DEFINE_GETTER(IndexBinary, FaissMetricType, metric_type)
 
 DEFINE_GETTER(IndexBinary, int, verbose);
 DEFINE_SETTER(IndexBinary, int, verbose);
+
+int faiss_IndexBinaryIVF_set_direct_map(
+        FaissIndexBinaryIVF* index,
+        int direct_map_type) {
+    try {
+        reinterpret_cast<faiss::IndexBinaryIVF*>(index)->set_direct_map_type(
+                static_cast<faiss::DirectMap::Type>(direct_map_type));
+    }
+    CATCH_AND_HANDLE
+}
 
 int faiss_IndexBinary_train(
         FaissIndexBinary* index,

--- a/c_api/IndexBinary_c.h
+++ b/c_api/IndexBinary_c.h
@@ -28,8 +28,10 @@ typedef struct FaissIDSelector_H FaissIDSelector;
 FAISS_DECLARE_CLASS(IndexBinary)
 FAISS_DECLARE_DESTRUCTOR(IndexBinary)
 
-FAISS_DECLARE_CLASS_INHERITED(IndexBinaryIVF, Index)
-FAISS_DECLARE_INDEX_DOWNCAST(IndexBinaryIVF)
+FAISS_DECLARE_CLASS_INHERITED(IndexBinaryIVF, IndexBinary)
+
+/// Cast function for IndexBinaryIVF
+FaissIndexBinaryIVF* faiss_IndexBinaryIVF_cast(FaissIndexBinary* index);
 
 /// Getter for d
 FAISS_DECLARE_GETTER(IndexBinary, int, d)
@@ -45,9 +47,7 @@ FAISS_DECLARE_GETTER(IndexBinary, FaissMetricType, metric_type)
 
 FAISS_DECLARE_GETTER_SETTER(IndexBinary, int, verbose)
 
-int faiss_IndexBinaryIVF_set_direct_map(
-        FaissIndexBinaryIVF* index,
-        int direct_map_type);
+FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nprobe)
 
 /** Perform training on a representative set of vectors
  *
@@ -168,6 +168,10 @@ int faiss_IndexBinary_reconstruct_n(
         idx_t i0,
         idx_t ni,
         uint8_t* recons);
+
+int faiss_IndexBinaryIVF_set_direct_map(
+        FaissIndexBinaryIVF* index,
+        int direct_map_type);
 
 #ifdef __cplusplus
 }

--- a/c_api/IndexBinary_c.h
+++ b/c_api/IndexBinary_c.h
@@ -52,9 +52,6 @@ FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nlist)
 
 FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nprobe)
 
-/// quantizer that maps vectors to inverted lists
-FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, FaissIndexBinary*, quantizer)
-
 /** Perform training on a representative set of vectors
  *
  * @param index  opaque pointer to index object
@@ -195,10 +192,6 @@ int faiss_IndexBinary_reconstruct_n(
         idx_t i0,
         idx_t ni,
         uint8_t* recons);
-
-int faiss_IndexBinaryIVF_set_direct_map(
-        FaissIndexBinaryIVF* index,
-        int direct_map_type);
 
 #ifdef __cplusplus
 }

--- a/c_api/IndexBinary_c.h
+++ b/c_api/IndexBinary_c.h
@@ -48,10 +48,6 @@ FAISS_DECLARE_GETTER(IndexBinary, FaissMetricType, metric_type)
 
 FAISS_DECLARE_GETTER_SETTER(IndexBinary, int, verbose)
 
-FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nlist)
-
-FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nprobe)
-
 /** Perform training on a representative set of vectors
  *
  * @param index  opaque pointer to index object

--- a/c_api/IndexBinary_c.h
+++ b/c_api/IndexBinary_c.h
@@ -47,6 +47,8 @@ FAISS_DECLARE_GETTER(IndexBinary, FaissMetricType, metric_type)
 
 FAISS_DECLARE_GETTER_SETTER(IndexBinary, int, verbose)
 
+FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nlist)
+
 FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nprobe)
 
 /** Perform training on a representative set of vectors
@@ -96,6 +98,27 @@ int faiss_IndexBinary_search(
         idx_t n,
         const uint8_t* x,
         idx_t k,
+        int32_t* distances,
+        idx_t* labels);
+
+/** query n vectors of dimension d to the index.
+ *
+ * return at most k vectors. If there are not enough results for a
+ * query, the result array is padded with -1s.
+ *
+ * @param index       opaque pointer to index object
+ * @param x           input vectors to search, size n * d
+ * @param k           number of results to return
+ * @param params      search parameters
+ * @param distances   output distances, size n*k
+ * @param labels      output labels of the NNs, size n*k
+ */
+int faiss_IndexBinary_search_with_params(
+        const FaissIndexBinary* index,
+        idx_t n,
+        const uint8_t* x,
+        idx_t k,
+        const FaissSearchParameters* params,
         int32_t* distances,
         idx_t* labels);
 

--- a/c_api/IndexBinary_c.h
+++ b/c_api/IndexBinary_c.h
@@ -37,7 +37,8 @@ FaissIndexBinaryIVF* faiss_IndexBinaryIVF_cast(FaissIndexBinary* index);
 FAISS_DECLARE_GETTER(IndexBinary, int, d)
 
 /// Getter for is_trained
-FAISS_DECLARE_GETTER(IndexBinary, int, is_trained)
+
+FAISS_DECLARE_GETTER_SETTER(IndexBinary, int, is_trained)
 
 /// Getter for ntotal
 FAISS_DECLARE_GETTER(IndexBinary, idx_t, ntotal)
@@ -50,6 +51,9 @@ FAISS_DECLARE_GETTER_SETTER(IndexBinary, int, verbose)
 FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nlist)
 
 FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, size_t, nprobe)
+
+/// quantizer that maps vectors to inverted lists
+FAISS_DECLARE_GETTER_SETTER(IndexBinaryIVF, FaissIndexBinary*, quantizer)
 
 /** Perform training on a representative set of vectors
  *

--- a/c_api/IndexBinary_c.h
+++ b/c_api/IndexBinary_c.h
@@ -28,6 +28,9 @@ typedef struct FaissIDSelector_H FaissIDSelector;
 FAISS_DECLARE_CLASS(IndexBinary)
 FAISS_DECLARE_DESTRUCTOR(IndexBinary)
 
+FAISS_DECLARE_CLASS_INHERITED(IndexBinaryIVF, Index)
+FAISS_DECLARE_INDEX_DOWNCAST(IndexBinaryIVF)
+
 /// Getter for d
 FAISS_DECLARE_GETTER(IndexBinary, int, d)
 
@@ -41,6 +44,10 @@ FAISS_DECLARE_GETTER(IndexBinary, idx_t, ntotal)
 FAISS_DECLARE_GETTER(IndexBinary, FaissMetricType, metric_type)
 
 FAISS_DECLARE_GETTER_SETTER(IndexBinary, int, verbose)
+
+int faiss_IndexBinaryIVF_set_direct_map(
+        FaissIndexBinaryIVF* index,
+        int direct_map_type);
 
 /** Perform training on a representative set of vectors
  *

--- a/c_api/IndexIVF_c.cpp
+++ b/c_api/IndexIVF_c.cpp
@@ -182,3 +182,27 @@ void faiss_IndexIVFStats_reset(FaissIndexIVFStats* stats) {
 FaissIndexIVFStats* faiss_get_indexIVF_stats() {
     return reinterpret_cast<FaissIndexIVFStats*>(&faiss::indexIVF_stats);
 }
+
+int faiss_IndexIVF_get_centroids(
+        const FaissIndexIVF* index,
+        float* centroids) {
+    try {
+        const IndexIVF* ivf = reinterpret_cast<const IndexIVF*>(index);
+        const faiss::Index* quantizer = ivf->quantizer;
+        
+        if (!quantizer) {
+            FAISS_THROW_MSG("No quantizer found in IVF index");
+        }
+        
+        // Get all centroids using reconstruct_n
+        quantizer->reconstruct_n(0, ivf->nlist, centroids);
+    }
+    CATCH_AND_HANDLE
+}
+
+int faiss_IndexIVF_free_centroids(float* centroids) {
+    try {
+        delete[] centroids;
+    }
+    CATCH_AND_HANDLE
+}

--- a/c_api/IndexIVF_c.h
+++ b/c_api/IndexIVF_c.h
@@ -177,6 +177,19 @@ inline void faiss_IndexIVFStats_init(FaissIndexIVFStats* stats) {
 /// global var that collects all statists
 FaissIndexIVFStats* faiss_get_indexIVF_stats();
 
+/** Get centroids from an IVF index
+ *
+ * @param index       IVF index
+ * @param centroids   output centroids, size nlist * d (allocated by caller)
+ * @return            0 if successful
+ */
+int faiss_IndexIVF_get_centroids(
+        const FaissIndexIVF* index,
+        float* centroids);
+
+// Free function for auto-allocated centroids
+int faiss_IndexIVF_free_centroids(float* centroids);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c_api/IndexIVF_c_ex.cpp
+++ b/c_api/IndexIVF_c_ex.cpp
@@ -38,16 +38,21 @@ int faiss_Search_closest_eligible_centroids(
         FaissIndex* index,
         idx_t n,
         const float* query,
-        idx_t k, 
+        idx_t k,
         float* centroid_distances,
         idx_t* centroid_ids,
         const FaissSearchParameters* params) {
     try {
-        faiss::IndexIVF* index_ivf = reinterpret_cast<IndexIVF*>(index); 
+        faiss::IndexIVF* index_ivf = reinterpret_cast<IndexIVF*>(index);
         assert(index_ivf);
 
-        index_ivf->quantizer->search(n, query, k, centroid_distances, centroid_ids,
-            reinterpret_cast<const faiss::SearchParameters*>(params));
+        index_ivf->quantizer->search(
+                n,
+                query,
+                k,
+                centroid_distances,
+                centroid_ids,
+                reinterpret_cast<const faiss::SearchParameters*>(params));
     }
     CATCH_AND_HANDLE
 }
@@ -58,7 +63,8 @@ int faiss_get_lists_for_keys(
         size_t n_keys,
         idx_t* lists) {
     try {
-        reinterpret_cast<IndexIVF*>(index)->get_lists_for_keys(keys, n_keys, lists);
+        reinterpret_cast<IndexIVF*>(index)->get_lists_for_keys(
+                keys, n_keys, lists);
     }
     CATCH_AND_HANDLE
 }
@@ -76,7 +82,14 @@ int faiss_IndexIVF_search_preassigned_with_params(
         const FaissSearchParametersIVF* params) {
     try {
         reinterpret_cast<const IndexIVF*>(index)->search_preassigned(
-                n, x, k, assign, centroid_dis, distances, labels, store_pairs,
+                n,
+                x,
+                k,
+                assign,
+                centroid_dis,
+                distances,
+                labels,
+                store_pairs,
                 reinterpret_cast<const faiss::SearchParametersIVF*>(params));
     }
     CATCH_AND_HANDLE
@@ -92,7 +105,7 @@ int faiss_IndexIVF_compute_distance_to_codes_for_list(
         float* dist_table) {
     try {
         reinterpret_cast<IndexIVF*>(index)->compute_distance_to_codes_for_list(
-               list_no, x, n, codes, dists, dist_table);
+                list_no, x, n, codes, dists, dist_table);
         return 0;
     }
     CATCH_AND_HANDLE
@@ -104,7 +117,7 @@ int faiss_IndexIVF_compute_distance_table(
         float* dist_table) {
     try {
         reinterpret_cast<IndexIVF*>(index)->compute_distance_table(
-               x, dist_table);
+                x, dist_table);
         return 0;
     }
     CATCH_AND_HANDLE

--- a/c_api/IndexIVF_c_ex.h
+++ b/c_api/IndexIVF_c_ex.h
@@ -12,16 +12,14 @@
 #define FAISS_INDEX_IVF_EX_C_H
 
 #include "Clustering_c.h"
+#include "IndexIVF_c.h"
 #include "Index_c.h"
 #include "faiss_c.h"
-#include "IndexIVF_c.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-int faiss_IndexIVF_set_direct_map(
-        FaissIndexIVF* index,
-        int direct_map_type);
+int faiss_IndexIVF_set_direct_map(FaissIndexIVF* index, int direct_map_type);
 
 int faiss_SearchParametersIVF_new_with_sel(
         FaissSearchParametersIVF** p_sp,
@@ -33,7 +31,7 @@ int faiss_SearchParametersIVF_new_with_sel(
     @param query: query vector.
     @param k: count of closest number of vectors.
     @param centroid_distances: output distances, size n * k.
-    @param centroid_ids: output centroid IDs, size n * k.    
+    @param centroid_ids: output centroid IDs, size n * k.
 */
 int faiss_Search_closest_eligible_centroids(
         FaissIndex* index,
@@ -42,17 +40,16 @@ int faiss_Search_closest_eligible_centroids(
         idx_t k,
         float* centroid_distances,
         idx_t* centroid_ids,
-        const FaissSearchParameters* params
-);
+        const FaissSearchParameters* params);
 
 /*
     Search the clusters whose IDs are in 'assign' and
-    return the 'k' nearest neighbours from among them.     
+    return the 'k' nearest neighbours from among them.
 
     @param n: number of queries.
     @param x: query vector, size n * d.
     @param k: count of nearest neighbours to be returned for each query.
-    @param centroid_ids: output centroid IDs, size n * k. 
+    @param centroid_ids: output centroid IDs, size n * k.
     @param distance: output distances, size n * k
     @param labels: output labels, size n * k
 */
@@ -94,18 +91,19 @@ int faiss_IndexIVF_compute_distance_to_codes_for_list(
         float* dist_table);
 
 /*
-    Given multiple vector IDs, retrieve the corresponding list (cluster) IDs  
-    from an IVF index. This function efficiently assigns vector IDs to their  
-    respective inverted lists/clusters in a batch operation.  
+    Given multiple vector IDs, retrieve the corresponding list (cluster) IDs
+    from an IVF index. This function efficiently assigns vector IDs to their
+    respective inverted lists/clusters in a batch operation.
 
-    @param index  - Pointer to the Faiss IVF index  
-    @param keys   - Input array of vector IDs (keys)  
-    @param n_keys - Number of vector keys in the input array  
-    @param lists  - Output array where corresponding cluster (list) IDs are stored  
+    @param index  - Pointer to the Faiss IVF index
+    @param keys   - Input array of vector IDs (keys)
+    @param n_keys - Number of vector keys in the input array
+    @param lists  - Output array where corresponding cluster (list) IDs are
+   stored
 */
 
 int faiss_get_lists_for_keys(
-        FaissIndexIVF* index, 
+        FaissIndexIVF* index,
         idx_t* keys,
         size_t n_keys,
         idx_t* lists);

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -9,8 +9,8 @@
 
 #include "Index_c.h"
 #include <faiss/Index.h>
-#include <faiss/impl/IDSelector.h>
 #include <faiss/OMPConfig.h>
+#include <faiss/impl/IDSelector.h>
 #include "macros_impl.h"
 
 extern "C" {
@@ -226,5 +226,4 @@ int faiss_Index_sa_decode(
 void faiss_set_omp_threads(unsigned int n) {
     faiss::set_num_omp_threads(n);
 }
-
 }

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -9,11 +9,16 @@
 
 #include "Index_c.h"
 #include <faiss/Index.h>
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexIDMap.h>
 #include <faiss/IndexIVF.h>
+#include <faiss/IndexScalarQuantizer.h>
 #include <faiss/OMPConfig.h>
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/IDSelector.h>
+#include <faiss/impl/io.h>
+#include <algorithm>
 #include "macros_impl.h"
 
 extern "C" {
@@ -239,19 +244,47 @@ int faiss_Index_dist_compute(
     try {
         const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
 
-        // Get a distance computer for this index
-        std::unique_ptr<faiss::DistanceComputer> dc(
-                idx->get_distance_computer());
-
-        // Set the query vector
-        dc->set_query(query);
-
-        // Compute distances for each ID
-        for (size_t i = 0; i < n_ids; i++) {
-            distances[i] = (*dc)(ids[i]);
+        // Try to cast to IndexIVFScalarQuantizer
+        if (auto ivfsq =
+                    dynamic_cast<const faiss::IndexIVFScalarQuantizer*>(idx)) {
+            ivfsq->dist_compute(query, ids, n_ids, distances);
+            return 0;
         }
 
-        return 0;
+        // Try to cast to IndexIDMap2
+        if (auto idmap2 = dynamic_cast<const faiss::IndexIDMap2*>(idx)) {
+            // Check if the underlying index is IndexFlat
+            auto flat = dynamic_cast<const faiss::IndexFlat*>(idmap2->index);
+            if (flat) {
+                std::vector<idx_t> internal_indices(n_ids, -1);
+                for (size_t i = 0; i < n_ids; ++i) {
+                    // Search for the ID in the id_map vector
+                    auto it = std::find(
+                            idmap2->id_map.begin(),
+                            idmap2->id_map.end(),
+                            ids[i]);
+                    if (it != idmap2->id_map.end()) {
+                        internal_indices[i] =
+                                std::distance(idmap2->id_map.begin(), it);
+                    }
+                    // else: leave as -1, or handle as you wish (e.g., set
+                    // distance to NaN)
+                }
+                flat->compute_distance_subset(
+                        1, query, n_ids, distances, internal_indices.data());
+                return 0;
+            }
+        }
+
+        // Try to cast to IndexFlat
+        if (auto flat = dynamic_cast<const faiss::IndexFlat*>(idx)) {
+            // For IndexFlat, we can use compute_distance_subset
+            flat->compute_distance_subset(1, query, n_ids, distances, ids);
+            return 0;
+        }
+
+        // If we get here, the index type doesn't support dist_compute
+        return -1;
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -235,19 +235,17 @@ void faiss_set_omp_threads(unsigned int n) {
     faiss::set_num_omp_threads(n);
 }
 
-int faiss_IndexIVF_dist_compute(
+int faiss_Index_dist_compute(
         const FaissIndex* index,
         const float* query,
         const idx_t* ids,
         size_t n_ids,
         float* distances) {
     try {
-        const faiss::IndexIVF* ivf = dynamic_cast<const faiss::IndexIVF*>(
-                reinterpret_cast<const faiss::Index*>(index));
-        FAISS_THROW_IF_NOT_MSG(ivf, "index is not an IVF index");
+        const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
         
         // Get a distance computer for this index
-        std::unique_ptr<faiss::DistanceComputer> dc(ivf->get_distance_computer());
+        std::unique_ptr<faiss::DistanceComputer> dc(idx->get_distance_computer());
         
         // Set the query vector
         dc->set_query(query);
@@ -256,6 +254,8 @@ int faiss_IndexIVF_dist_compute(
         for (size_t i = 0; i < n_ids; i++) {
             distances[i] = (*dc)(ids[i]);
         }
+        
+        return 0;
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -10,10 +10,10 @@
 #include "Index_c.h"
 #include <faiss/Index.h>
 #include <faiss/IndexIVF.h>
-#include <faiss/impl/IDSelector.h>
 #include <faiss/OMPConfig.h>
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/IDSelector.h>
 #include "macros_impl.h"
 
 extern "C" {
@@ -238,21 +238,21 @@ int faiss_Index_dist_compute(
         float* distances) {
     try {
         const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
-        
+
         // Get a distance computer for this index
-        std::unique_ptr<faiss::DistanceComputer> dc(idx->get_distance_computer());
-        
+        std::unique_ptr<faiss::DistanceComputer> dc(
+                idx->get_distance_computer());
+
         // Set the query vector
         dc->set_query(query);
-        
+
         // Compute distances for each ID
         for (size_t i = 0; i < n_ids; i++) {
             distances[i] = (*dc)(ids[i]);
         }
-        
+
         return 0;
     }
     CATCH_AND_HANDLE
 }
-
 }

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -9,16 +9,11 @@
 
 #include "Index_c.h"
 #include <faiss/Index.h>
-<<<<<<< HEAD
-#include <faiss/OMPConfig.h>
-#include <faiss/impl/IDSelector.h>
-=======
 #include <faiss/IndexIVF.h>
 #include <faiss/impl/IDSelector.h>
 #include <faiss/OMPConfig.h>
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
->>>>>>> afecdb51 (added a dist computer)
 #include "macros_impl.h"
 
 extern "C" {

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -235,6 +235,23 @@ void faiss_set_omp_threads(unsigned int n) {
     faiss::set_num_omp_threads(n);
 }
 
+int faiss_SearchParameters_new_with_selector(
+        FaissSearchParameters** p_sp,
+        FaissIDSelector* sel) {
+    try {
+        // Create new SearchParameters object
+        auto* sp = new faiss::SearchParameters();
+        
+        // Set the selector during construction
+        sp->sel = reinterpret_cast<faiss::IDSelector*>(sel);
+        
+        // Assign to output parameter
+        *p_sp = reinterpret_cast<FaissSearchParameters*>(sp);
+    }
+    CATCH_AND_HANDLE
+}
+
+
 int faiss_Index_dist_compute(
         const FaissIndex* index,
         const float* query,

--- a/c_api/Index_c.h
+++ b/c_api/Index_c.h
@@ -280,15 +280,15 @@ int faiss_Index_sa_decode(
 void faiss_set_omp_threads(unsigned int n);
 
 
-/** Compute distances between a query vector and a set of vectors for IVF indices
+/** Compute distances between a query vector and a set of vectors 
  *
- * @param index       opaque pointer to IVF index object
+ * @param index       opaque pointer to index object
  * @param query       query vector, size d
  * @param ids         array of vector ids to compute distances to
  * @param n_ids       number of ids in the array
  * @param distances   output distances, size n_ids
  */
-int faiss_IndexIVF_dist_compute(
+int faiss_Index_dist_compute(
         const FaissIndex* index,
         const float* query,
         const idx_t* ids,

--- a/c_api/Index_c.h
+++ b/c_api/Index_c.h
@@ -63,6 +63,9 @@ FAISS_DECLARE_GETTER(Index, FaissMetricType, metric_type)
 
 FAISS_DECLARE_GETTER_SETTER(Index, int, verbose)
 
+FAISS_DECLARE_CLASS(IndexBinary)
+FAISS_DECLARE_DESTRUCTOR(IndexBinary)
+
 /** Perform training on a representative set of vectors
  *
  * @param index  opaque pointer to index object

--- a/c_api/Index_c.h
+++ b/c_api/Index_c.h
@@ -279,6 +279,9 @@ int faiss_Index_sa_decode(
 
 void faiss_set_omp_threads(unsigned int n);
 
+int faiss_SearchParameters_new_with_selector(
+        FaissSearchParameters** p_sp,
+        FaissIDSelector* sel);
 
 /** Compute distances between a query vector and a set of vectors 
  *

--- a/c_api/Index_c.h
+++ b/c_api/Index_c.h
@@ -279,6 +279,22 @@ int faiss_Index_sa_decode(
 
 void faiss_set_omp_threads(unsigned int n);
 
+
+/** Compute distances between a query vector and a set of vectors for IVF indices
+ *
+ * @param index       opaque pointer to IVF index object
+ * @param query       query vector, size d
+ * @param ids         array of vector ids to compute distances to
+ * @param n_ids       number of ids in the array
+ * @param distances   output distances, size n_ids
+ */
+int faiss_IndexIVF_dist_compute(
+        const FaissIndex* index,
+        const float* query,
+        const idx_t* ids,
+        size_t n_ids,
+        float* distances);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -14,15 +14,22 @@
 
 extern "C" {
 
-int faiss_Index_reconstruct_batch(const FaissIndex* index, idx_t n, const idx_t* keys, float* recons) {
+int faiss_Index_reconstruct_batch(
+        const FaissIndex* index,
+        idx_t n,
+        const idx_t* keys,
+        float* recons) {
     try {
-        reinterpret_cast<const faiss::Index*>(index)->reconstruct_batch(n, keys, recons);
+        reinterpret_cast<const faiss::Index*>(index)->reconstruct_batch(
+                n, keys, recons);
     }
     CATCH_AND_HANDLE
 }
 
-
-int faiss_Index_merge_from(FaissIndex* index, FaissIndex* other, const idx_t add_id) {
+int faiss_Index_merge_from(
+        FaissIndex* index,
+        FaissIndex* other,
+        const idx_t add_id) {
     try {
         reinterpret_cast<faiss::Index*>(index)->merge_from(
                 *reinterpret_cast<faiss::Index*>(other), add_id);
@@ -35,5 +42,4 @@ size_t faiss_Index_size(FaissIndex* index) {
     size_t rv = sizeof(xIndex);
     return rv;
 }
-
 }

--- a/c_api/Index_c_ex.h
+++ b/c_api/Index_c_ex.h
@@ -13,17 +13,18 @@
 
 #include <stddef.h>
 #include <stdio.h>
-#include "faiss_c.h"
 #include "Index_c.h"
-
+#include "faiss_c.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int faiss_Index_reconstruct_batch(const FaissIndex* index, idx_t n,
-        const idx_t* keys, float* recons);
-
+int faiss_Index_reconstruct_batch(
+        const FaissIndex* index,
+        idx_t n,
+        const idx_t* keys,
+        float* recons);
 
 int faiss_Index_merge_from(FaissIndex* index, FaissIndex* other, idx_t add_id);
 

--- a/c_api/index_factory_c.cpp
+++ b/c_api/index_factory_c.cpp
@@ -29,16 +29,13 @@ int faiss_index_factory(
     CATCH_AND_HANDLE
 }
 
-/** Build an index with the sequence of processing steps described in
- *  the string.
- */
 int faiss_index_binary_factory(
-        FaissIndexBinary** p_index,
-        int d,
-        const char* description) {
+    FaissIndexBinary** p_index,
+    int d,
+    const char* description) {
     try {
-        *p_index = reinterpret_cast<FaissIndexBinary*>(
-                faiss::index_binary_factory(d, description));
+        *p_index = reinterpret_cast<FaissIndexBinary*>(faiss::index_binary_factory(
+                d, description));
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/index_factory_c.h
+++ b/c_api/index_factory_c.h
@@ -28,9 +28,9 @@ int faiss_index_factory(
         FaissMetricType metric);
 
 int faiss_index_binary_factory(
-    FaissIndexBinary** p_index,
-    int d,
-    const char* description);
+        FaissIndexBinary** p_index,
+        int d,
+        const char* description);
 
 #ifdef __cplusplus
 }

--- a/c_api/index_factory_c.h
+++ b/c_api/index_factory_c.h
@@ -27,13 +27,10 @@ int faiss_index_factory(
         const char* description,
         FaissMetricType metric);
 
-/** Build a binary index with the sequence of processing steps described in
- *  the string.
- */
 int faiss_index_binary_factory(
-        FaissIndexBinary** p_index,
-        int d,
-        const char* description);
+    FaissIndexBinary** p_index,
+    int d,
+    const char* description);
 
 #ifdef __cplusplus
 }

--- a/c_api/index_io_c.cpp
+++ b/c_api/index_io_c.cpp
@@ -9,8 +9,8 @@
 // I/O code for indexes
 
 #include "index_io_c.h"
-#include <faiss/index_io.h>
 #include <faiss/impl/io.h>
+#include <faiss/index_io.h>
 #include "macros_impl.h"
 
 using faiss::Index;

--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -10,8 +10,8 @@
 // More I/O code for indexes
 
 #include "index_io_c_ex.h"
-#include <faiss/index_io.h>
 #include <faiss/impl/io.h>
+#include <faiss/index_io.h>
 #include "macros_impl.h"
 
 using faiss::Index;
@@ -21,7 +21,8 @@ int faiss_write_index_buf(const FaissIndex* idx, size_t* size, uint8_t** buf) {
     try {
         faiss::VectorIOWriter writer;
         faiss::write_index(reinterpret_cast<const Index*>(idx), &writer);
-        uint8_t* tempBuf = (uint8_t*)malloc((writer.data.size()) * sizeof(uint8_t));
+        uint8_t* tempBuf =
+                (uint8_t*)malloc((writer.data.size()) * sizeof(uint8_t));
         std::copy(writer.data.begin(), writer.data.end(), tempBuf);
         *buf = tempBuf;
         *size = writer.data.size();
@@ -30,7 +31,11 @@ int faiss_write_index_buf(const FaissIndex* idx, size_t* size, uint8_t** buf) {
     CATCH_AND_HANDLE
 }
 
-int faiss_read_index_buf(const uint8_t* buf, size_t size, int io_flags, FaissIndex** p_out) {
+int faiss_read_index_buf(
+        const uint8_t* buf,
+        size_t size,
+        int io_flags,
+        FaissIndex** p_out) {
     try {
         faiss::BufIOReader reader;
         reader.buf = buf;

--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -46,6 +46,19 @@ int faiss_read_index_buf(
     CATCH_AND_HANDLE
 }
 
+int faiss_write_index_binary_buf(const FaissIndexBinary* idx, size_t* size, uint8_t** buf) {
+    try {
+        faiss::VectorIOWriter writer;
+        faiss::write_index_binary(reinterpret_cast<const IndexBinary*>(idx), &writer);
+        uint8_t* tempBuf = (uint8_t*)malloc((writer.data.size()) * sizeof(uint8_t));
+        std::copy(writer.data.begin(), writer.data.end(), tempBuf);
+        *buf = tempBuf;
+        *size = writer.data.size();
+        writer.data.clear();
+    }
+    CATCH_AND_HANDLE
+}
+
 int faiss_read_index_binary_buf(const uint8_t* buf, size_t size, int io_flags, FaissIndexBinary** p_out) {
     try {
         faiss::BufIOReader reader;

--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -46,6 +46,17 @@ int faiss_read_index_buf(
     CATCH_AND_HANDLE
 }
 
+int faiss_read_index_binary_buf(const uint8_t* buf, size_t size, int io_flags, FaissIndexBinary** p_out) {
+    try {
+        faiss::BufIOReader reader;
+        reader.buf = buf;
+        reader.buf_size = size;
+        auto index = faiss::read_index_binary(&reader, io_flags);
+        *p_out = reinterpret_cast<FaissIndexBinary*>(index);
+    }
+    CATCH_AND_HANDLE
+}
+
 void faiss_free_buf(uint8_t** buf) {
     free(*buf);
     *buf = nullptr;

--- a/c_api/index_io_c_ex.h
+++ b/c_api/index_io_c_ex.h
@@ -24,18 +24,24 @@ extern "C" {
 // skip prefetch phase while searching over the inverted lists
 #define FAISS_IO_FLAG_SKIP_PREFETCH 32
 // the following two macros together decide whether to read the index from an
-// already mmap'd data buffer. it's C equivalent of IO_FLAG_READ_MMAP from index_io.h
-// usage is - FAISS_IO_FLAG_READ_MMAP | FAISS_IO_FLAG_ONDISK_IVF
+// already mmap'd data buffer. it's C equivalent of IO_FLAG_READ_MMAP from
+// index_io.h usage is - FAISS_IO_FLAG_READ_MMAP | FAISS_IO_FLAG_ONDISK_IVF
 #define FAISS_IO_FLAG_READ_MMAP 64
 #define FAISS_IO_FLAG_ONDISK_IVF 0x646f0000
 
 /** Write index to buffer
  */
-int faiss_write_index_buf(const FaissIndex* idx, size_t* buf_size, uint8_t** buf);
+int faiss_write_index_buf(
+        const FaissIndex* idx,
+        size_t* buf_size,
+        uint8_t** buf);
 
 /** Read index from buffer
  */
-int faiss_read_index_buf(const uint8_t* buf, size_t limit, int io_flags,
+int faiss_read_index_buf(
+        const uint8_t* buf,
+        size_t limit,
+        int io_flags,
         FaissIndex** p_out);
 
 void faiss_free_buf(uint8_t** buf);

--- a/c_api/index_io_c_ex.h
+++ b/c_api/index_io_c_ex.h
@@ -44,6 +44,11 @@ int faiss_read_index_buf(
         int io_flags,
         FaissIndex** p_out);
 
+int faiss_write_index_binary_buf(const FaissIndexBinary* idx, size_t* buf_size, uint8_t** buf);
+
+int faiss_read_index_binary_buf(const uint8_t* buf, size_t limit, int io_flags,
+        FaissIndexBinary** p_out);
+
 void faiss_free_buf(uint8_t** buf);
 
 #ifdef __cplusplus

--- a/c_api/macros_impl.h
+++ b/c_api/macros_impl.h
@@ -98,10 +98,10 @@
                 reinterpret_cast<faiss::Index*>(index)));                   \
     }
 
-#define DEFINE_INDEXBINARY_DOWNCAST(clazz)                                        \
-    Faiss##clazz* faiss_##clazz##_cast(FaissIndexBinary* index) {                 \
+#define DEFINE_INDEXBINARY_DOWNCAST(clazz)                                  \
+    Faiss##clazz* faiss_##clazz##_cast(FaissIndexBinary* index) {           \
         return reinterpret_cast<Faiss##clazz*>(dynamic_cast<faiss::clazz*>( \
-                reinterpret_cast<faiss::IndexBinary*>(index)));                   \
+                reinterpret_cast<faiss::IndexBinary*>(index)));             \
     }
 
 #define DEFINE_SEARCH_PARAMETERS_DOWNCAST(clazz)                            \

--- a/c_api/macros_impl.h
+++ b/c_api/macros_impl.h
@@ -98,6 +98,12 @@
                 reinterpret_cast<faiss::Index*>(index)));                   \
     }
 
+#define DEFINE_INDEXBINARY_DOWNCAST(clazz)                                        \
+    Faiss##clazz* faiss_##clazz##_cast(FaissIndexBinary* index) {                 \
+        return reinterpret_cast<Faiss##clazz*>(dynamic_cast<faiss::clazz*>( \
+                reinterpret_cast<faiss::IndexBinary*>(index)));                   \
+    }
+
 #define DEFINE_SEARCH_PARAMETERS_DOWNCAST(clazz)                            \
     Faiss##clazz* faiss_##clazz##_cast(FaissSearchParameters* sp) {         \
         return reinterpret_cast<Faiss##clazz*>(dynamic_cast<faiss::clazz*>( \

--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -17,8 +17,8 @@
 #include <cstdio>
 #include <cstring>
 
-#include <omp.h>
 #include <faiss/OMPConfig.h>
+#include <omp.h>
 
 #include <faiss/IndexFlat.h>
 #include <faiss/impl/FaissAssert.h>

--- a/faiss/Index.cpp
+++ b/faiss/Index.cpp
@@ -58,7 +58,7 @@ void Index::reconstruct(idx_t, float*) const {
 void Index::reconstruct_batch(idx_t n, const idx_t* keys, float* recons) const {
     std::mutex exception_mutex;
     std::string exception_string;
-    #pragma omp parallel for if (n > 1000) num_threads(num_omp_threads)
+#pragma omp parallel for if (n > 1000) num_threads(num_omp_threads)
     for (idx_t i = 0; i < n; i++) {
         try {
             reconstruct(keys[i], &recons[i * d]);

--- a/faiss/Index.cpp
+++ b/faiss/Index.cpp
@@ -58,7 +58,7 @@ void Index::reconstruct(idx_t, float*) const {
 void Index::reconstruct_batch(idx_t n, const idx_t* keys, float* recons) const {
     std::mutex exception_mutex;
     std::string exception_string;
-#pragma omp parallel for if (n > 1000) num_threads(num_omp_threads)
+// #pragma omp parallel for if (n > 1000) num_threads(num_omp_threads)
     for (idx_t i = 0; i < n; i++) {
         try {
             reconstruct(keys[i], &recons[i * d]);

--- a/faiss/Index.cpp
+++ b/faiss/Index.cpp
@@ -58,7 +58,7 @@ void Index::reconstruct(idx_t, float*) const {
 void Index::reconstruct_batch(idx_t n, const idx_t* keys, float* recons) const {
     std::mutex exception_mutex;
     std::string exception_string;
-// #pragma omp parallel for if (n > 1000) num_threads(num_omp_threads)
+    #pragma omp parallel for if (n > 1000) num_threads(num_omp_threads)
     for (idx_t i = 0; i < n; i++) {
         try {
             reconstruct(keys[i], &recons[i * d]);

--- a/faiss/IndexBinaryFlat.cpp
+++ b/faiss/IndexBinaryFlat.cpp
@@ -85,7 +85,8 @@ void IndexBinaryFlat::search(
                     k,
                     code_size,
                     distances + s * k,
-                    labels + s * k);
+                    labels + s * k,
+                    sel);
         }
     }
 }

--- a/faiss/IndexBinaryFlat.cpp
+++ b/faiss/IndexBinaryFlat.cpp
@@ -25,8 +25,21 @@ void IndexBinaryFlat::add(idx_t n, const uint8_t* x) {
     ntotal += n;
 }
 
+void IndexBinaryFlat::add_with_ids(idx_t n, const uint8_t* x, const idx_t* xids) {
+    xb.insert(xb.end(), x, x + n * code_size);
+    if (xids) {
+        ids.insert(ids.end(), xids, xids + n);
+    } else {
+        for (idx_t i = 0; i < n; i++) {
+            ids.push_back(ntotal + i);
+        }
+    }
+    ntotal += n;
+}
+
 void IndexBinaryFlat::reset() {
     xb.clear();
+    ids.clear();
     ntotal = 0;
 }
 
@@ -63,6 +76,8 @@ void IndexBinaryFlat::search(
                     approx_topk_mode,
                     sel);
         } else {
+            printf("don't use heap \n");
+
             hammings_knn_mc(
                     x + s * code_size,
                     xb.data(),
@@ -71,8 +86,7 @@ void IndexBinaryFlat::search(
                     k,
                     code_size,
                     distances + s * k,
-                    labels + s * k,
-                    sel);
+                    labels + s * k);
         }
     }
 }

--- a/faiss/IndexBinaryFlat.cpp
+++ b/faiss/IndexBinaryFlat.cpp
@@ -131,7 +131,7 @@ size_t IndexBinaryFlat::remove_ids(const IDSelector& sel) {
     if (nremove > 0) {
         ntotal = j;
         xb.resize(ntotal * code_size);
-        ids.resize(ntotal);  // Resize the ids vector
+        ids.resize(ntotal); // Resize the ids vector
     }
     return nremove;
 }
@@ -155,14 +155,19 @@ void IndexBinaryFlat::range_search(
             x, xb.data(), n, ntotal, radius, code_size, &tmp_result, sel);
 
     // Convert indices to actual IDs in the final result
+    RangeSearchPartialResult pres(result);
     for (idx_t i = 0; i < n; i++) {
-        RangeQueryResult& qres = tmp_result.lims[i];
-        for (idx_t j = 0; j < qres.nres; j++) {
-            if (qres.ids[j] >= 0) {
-                result->add(i, qres.dists[j], ids[qres.ids[j]]);
+        RangeQueryResult& qres = pres.new_result(i);
+        size_t start = tmp_result.lims[i];
+        size_t end = tmp_result.lims[i + 1];
+        for (size_t j = start; j < end; j++) {
+            idx_t id = ids[tmp_result.labels[j]];
+            if (!sel || sel->is_member(id)) {
+                qres.add(tmp_result.distances[j], id);
             }
         }
     }
+    pres.finalize();
 }
 
 } // namespace faiss

--- a/faiss/IndexBinaryFlat.cpp
+++ b/faiss/IndexBinaryFlat.cpp
@@ -76,8 +76,7 @@ void IndexBinaryFlat::search(
                     approx_topk_mode,
                     sel);
         } else {
-            printf("don't use heap \n");
-
+            
             hammings_knn_mc(
                     x + s * code_size,
                     xb.data(),

--- a/faiss/IndexBinaryFlat.h
+++ b/faiss/IndexBinaryFlat.h
@@ -22,7 +22,8 @@ namespace faiss {
 /** Index that stores the full vectors and performs exhaustive search. */
 struct IndexBinaryFlat : IndexBinary {
     /// database vectors, size ntotal * d / 8
-    MaybeOwnedVector<uint8_t> xb;
+    std::vector<uint8_t> xb;
+    std::vector<idx_t> ids;
 
     /** Select between using a heap or counting to select the k smallest values
      * when scanning inverted lists.
@@ -36,6 +37,8 @@ struct IndexBinaryFlat : IndexBinary {
     explicit IndexBinaryFlat(idx_t d);
 
     void add(idx_t n, const uint8_t* x) override;
+
+    void add_with_ids(idx_t n, const uint8_t* x, const idx_t* xids) override;
 
     void reset() override;
 

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -115,8 +115,6 @@ void IndexBinaryIVF::search(
         int32_t* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(nprobe > 0);
 
@@ -131,8 +129,11 @@ void IndexBinaryIVF::search(
     t0 = getmillisecs();
     invlists->prefetch_lists(idx.get(), n * nprobe_2);
 
+    const IVFSearchParameters* params2 = reinterpret_cast<const IVFSearchParameters*>(params);
+    const IDSelector* sel = params2 ? params2->sel : nullptr;
     search_preassigned(
-            n, x, k, idx.get(), coarse_dis.get(), distances, labels, false);
+            n, x, k, idx.get(), coarse_dis.get(), distances, labels, false, params2, sel);
+
     indexIVF_stats.search_time += getmillisecs() - t0;
 }
 
@@ -314,8 +315,10 @@ struct IVFBinaryScannerL2 : BinaryInvertedListScanner {
     size_t code_size;
     bool store_pairs;
 
-    IVFBinaryScannerL2(size_t code_size, bool store_pairs)
-            : code_size(code_size), store_pairs(store_pairs) {}
+    IVFBinaryScannerL2(size_t code_size, bool store_pairs, const IDSelector* sel = nullptr)
+            : BinaryInvertedListScanner(store_pairs, sel),
+              code_size(code_size),
+              store_pairs(store_pairs) {}
 
     void set_query(const uint8_t* query_vector) override {
         hc.set(query_vector, code_size);
@@ -330,43 +333,47 @@ struct IVFBinaryScannerL2 : BinaryInvertedListScanner {
         return hc.hamming(code);
     }
 
-    size_t scan_codes(
-            size_t n,
-            const uint8_t* __restrict codes,
-            const idx_t* __restrict ids,
-            int32_t* __restrict simi,
-            idx_t* __restrict idxi,
-            size_t k) const override {
-        using C = CMax<int32_t, idx_t>;
+   size_t scan_codes(
+        size_t n,
+        const uint8_t* __restrict codes,
+        const idx_t* __restrict ids,
+        int32_t* __restrict simi,
+        idx_t* __restrict idxi,
+        size_t k) const override {
+    using C = CMax<int32_t, idx_t>;
 
-        size_t nup = 0;
-        for (size_t j = 0; j < n; j++) {
-            uint32_t dis = hc.hamming(codes);
-            if (dis < simi[0]) {
-                idx_t id = store_pairs ? lo_build(list_no, j) : ids[j];
+    for (size_t j = 0; j < n; j++) {
+        uint32_t dis = hc.hamming(codes);
+        if (dis < simi[0]) {
+            idx_t id = store_pairs ? lo_build(list_no, j) : ids[j];
+            // Add selector check
+            if (!sel || sel->is_member(id)) {
                 heap_replace_top<C>(k, simi, idxi, dis, id);
-                nup++;
-            }
-            codes += code_size;
+            } 
         }
-        return nup;
+        codes += code_size;
     }
+}
 
-    void scan_codes_range(
-            size_t n,
-            const uint8_t* __restrict codes,
-            const idx_t* __restrict ids,
-            int radius,
-            RangeQueryResult& result) const override {
-        for (size_t j = 0; j < n; j++) {
-            uint32_t dis = hc.hamming(codes);
-            if (dis < radius) {
-                int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
+   void scan_codes_range(
+        size_t n,
+        const uint8_t* __restrict codes,
+        const idx_t* __restrict ids,
+        int radius,
+        RangeQueryResult& result) const override {
+    for (size_t j = 0; j < n; j++) {
+        uint32_t dis = hc.hamming(codes);
+        if (dis < radius) {
+            int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
+            // Add selector check
+            if (!sel || sel->is_member(id)) {
                 result.add(dis, id);
             }
-            codes += code_size;
         }
+        codes += code_size;
     }
+}
+
 };
 
 void search_knn_hamming_heap(
@@ -384,6 +391,7 @@ void search_knn_hamming_heap(
     nprobe = std::min((idx_t)ivf->nlist, nprobe);
     idx_t max_codes = params ? params->max_codes : ivf->max_codes;
     MetricType metric_type = ivf->metric_type;
+    const IDSelector* sel = params ? params->sel : nullptr;
 
     // almost verbatim copy from IndexIVF::search_preassigned
 
@@ -394,7 +402,7 @@ void search_knn_hamming_heap(
 #pragma omp parallel if (n > 1) reduction(+ : nlistv, ndis, nheap) num_threads(num_omp_threads)
     {
         std::unique_ptr<BinaryInvertedListScanner> scanner(
-                ivf->get_InvertedListScanner(store_pairs));
+                ivf->get_InvertedListScanner(store_pairs, sel));
 
 #pragma omp for
         for (idx_t i = 0; i < n; i++) {
@@ -759,47 +767,64 @@ struct BuildScanner {
     using T = BinaryInvertedListScanner*;
 
     template <class HammingComputer>
-    T f(size_t code_size, bool store_pairs) {
-        return new IVFBinaryScannerL2<HammingComputer>(code_size, store_pairs);
+    T f(size_t code_size, bool store_pairs, const IDSelector* sel) {
+        return new IVFBinaryScannerL2<HammingComputer>(code_size, store_pairs, sel);
     }
 };
 
 } // anonymous namespace
 
 BinaryInvertedListScanner* IndexBinaryIVF::get_InvertedListScanner(
-        bool store_pairs) const {
-    BuildScanner bs;
-    return dispatch_HammingComputer(code_size, bs, code_size, store_pairs);
+        bool store_pairs,
+        const IDSelector* sel) const {
+    // Choose the appropriate HammingComputer type based on code_size
+    if (code_size == 4) {
+        return new IVFBinaryScannerL2<HammingComputer4>(code_size, store_pairs, sel);
+    } else if (code_size == 8) {
+        return new IVFBinaryScannerL2<HammingComputer8>(code_size, store_pairs, sel);
+    } else if (code_size == 16) {
+        return new IVFBinaryScannerL2<HammingComputer16>(code_size, store_pairs, sel);
+    } else if (code_size == 20) {
+        return new IVFBinaryScannerL2<HammingComputer20>(code_size, store_pairs, sel);
+    } else if (code_size == 32) {
+        return new IVFBinaryScannerL2<HammingComputer32>(code_size, store_pairs, sel);
+    } else if (code_size == 64) {
+        return new IVFBinaryScannerL2<HammingComputer64>(code_size, store_pairs, sel);
+    } else {
+        return new IVFBinaryScannerL2<HammingComputerDefault>(code_size, store_pairs, sel);
+    }
 }
 
 void IndexBinaryIVF::search_preassigned(
         idx_t n,
         const uint8_t* x,
         idx_t k,
-        const idx_t* cidx,
-        const int32_t* cdis,
-        int32_t* dis,
-        idx_t* idx,
+        const idx_t* assign,
+        const int32_t* centroid_dis,
+        int32_t* distances,
+        idx_t* labels,
         bool store_pairs,
-        const IVFSearchParameters* params) const {
+        const IVFSearchParameters* params,
+        const IDSelector* sel) const {
+    
     if (per_invlist_search) {
         Run_search_knn_hamming_per_invlist r;
         // clang-format off
         dispatch_HammingComputer(
                 code_size, r, this, n, x, k,
-                cidx, cdis, dis, idx, store_pairs, params);
+                assign, centroid_dis, distances, labels, store_pairs, params);
         // clang-format on
     } else if (use_heap) {
         search_knn_hamming_heap(
-                this, n, x, k, cidx, cdis, dis, idx, store_pairs, params);
+                this, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params);
     } else if (store_pairs) { // !use_heap && store_pairs
         Run_search_knn_hamming_count<true> r;
         dispatch_HammingComputer(
-                code_size, r, this, n, x, cidx, k, dis, idx, params);
+                code_size, r, this, n, x, assign, k, distances, labels, params);
     } else { // !use_heap && !store_pairs
         Run_search_knn_hamming_count<false> r;
         dispatch_HammingComputer(
-                code_size, r, this, n, x, cidx, k, dis, idx, params);
+                code_size, r, this, n, x, assign, k, distances, labels, params);
     }
 }
 

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -120,7 +120,7 @@ void IndexBinaryIVF::search(
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(nprobe > 0);
 
-    const size_t nprobe_2 = std::min(nlist, this->nprobe);
+    const size_t nprobe_2 = 70; // std::min(nlist, this->nprobe);
     std::unique_ptr<idx_t[]> idx(new idx_t[n * nprobe_2]);
     std::unique_ptr<int32_t[]> coarse_dis(new int32_t[n * nprobe_2]);
 

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -120,7 +120,7 @@ void IndexBinaryIVF::search(
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(nprobe > 0);
 
-    const size_t nprobe_2 = 70; // std::min(nlist, this->nprobe);
+    const size_t nprobe_2 = std::min(nlist, this->nprobe);
     std::unique_ptr<idx_t[]> idx(new idx_t[n * nprobe_2]);
     std::unique_ptr<int32_t[]> coarse_dis(new int32_t[n * nprobe_2]);
 

--- a/faiss/IndexBinaryIVF.h
+++ b/faiss/IndexBinaryIVF.h
@@ -121,10 +121,11 @@ struct IndexBinaryIVF : IndexBinary {
             int32_t* distances,
             idx_t* labels,
             bool store_pairs,
-            const IVFSearchParameters* params = nullptr) const;
+            const IVFSearchParameters* params = nullptr,
+            const IDSelector* sel = nullptr) const;
 
     virtual BinaryInvertedListScanner* get_InvertedListScanner(
-            bool store_pairs = false) const;
+            bool store_pairs = false,const IDSelector* sel = nullptr) const;
 
     /** assign the vectors, then call search_preassign */
     void search(
@@ -218,6 +219,20 @@ struct IndexBinaryIVF : IndexBinary {
 };
 
 struct BinaryInvertedListScanner {
+    
+    bool store_pairs;
+    const IDSelector* sel;
+    idx_t list_no;
+    const uint8_t* query_vector;
+
+    BinaryInvertedListScanner(
+            bool store_pairs = false,
+            const IDSelector* sel = nullptr)
+            : store_pairs(store_pairs),
+              sel(sel),
+              list_no(-1),
+              query_vector(nullptr) {}
+    
     /// from now on we handle this query.
     virtual void set_query(const uint8_t* query_vector) = 0;
 

--- a/faiss/IndexBinaryIVF.h
+++ b/faiss/IndexBinaryIVF.h
@@ -125,7 +125,10 @@ struct IndexBinaryIVF : IndexBinary {
             const IDSelector* sel = nullptr) const;
 
     virtual BinaryInvertedListScanner* get_InvertedListScanner(
-            bool store_pairs = false,const IDSelector* sel = nullptr) const;
+            bool store_pairs = false,
+            const IDSelector* sel = nullptr) const;
+
+    void get_lists_for_keys(idx_t* keys, size_t n_keys, idx_t* lists);
 
     /** assign the vectors, then call search_preassign */
     void search(
@@ -219,7 +222,6 @@ struct IndexBinaryIVF : IndexBinary {
 };
 
 struct BinaryInvertedListScanner {
-    
     bool store_pairs;
     const IDSelector* sel;
     idx_t list_no;
@@ -232,7 +234,7 @@ struct BinaryInvertedListScanner {
               sel(sel),
               list_no(-1),
               query_vector(nullptr) {}
-    
+
     /// from now on we handle this query.
     virtual void set_query(const uint8_t* query_vector) = 0;
 

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -453,7 +453,8 @@ void IndexIVF::search_preassigned(
     void* inverted_list_context =
             params ? params->inverted_list_context : nullptr;
 
-#pragma omp parallel if (do_parallel) reduction(+ : nlistv, ndis, nheap) num_threads(num_omp_threads)
+#pragma omp parallel if (do_parallel) reduction(+ : nlistv, ndis, nheap) \
+        num_threads(num_omp_threads)
     {
         std::unique_ptr<InvertedListScanner> scanner(
                 get_InvertedListScanner(store_pairs, sel, params));
@@ -793,7 +794,8 @@ void IndexIVF::range_search_preassigned(
     void* inverted_list_context =
             params ? params->inverted_list_context : nullptr;
 
-#pragma omp parallel if (do_parallel) reduction(+ : nlistv, ndis) num_threads(num_omp_threads)
+#pragma omp parallel if (do_parallel) reduction(+ : nlistv, ndis) \
+        num_threads(num_omp_threads)
     {
         RangeSearchPartialResult pres(result);
         std::unique_ptr<InvertedListScanner> scanner(

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -449,7 +449,6 @@ struct IndexIVF : Index, IndexIVFInterface {
      */
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
 
-
     /** Given a query vector x, compute distance to provided codes
      * for the input list_no. This is a special purpose method
      * to be used as a flat distance computer for an inverted
@@ -466,12 +465,12 @@ struct IndexIVF : Index, IndexIVFInterface {
      */
 
     virtual void compute_distance_to_codes_for_list(
-        const idx_t list_no,
-        const float* x,
-        idx_t n,
-        const uint8_t* codes,
-        float* dists,
-        float* dist_table) const {};
+            const idx_t list_no,
+            const float* x,
+            idx_t n,
+            const uint8_t* codes,
+            float* dists,
+            float* dist_table) const {};
 
     /** Given a query vector x, compute distance table and
      *  return to the caller.
@@ -481,10 +480,8 @@ struct IndexIVF : Index, IndexIVFInterface {
      *
      */
 
-    virtual void compute_distance_table(
-        const float* x,
-        float* dist_table) const {};
-
+    virtual void compute_distance_table(const float* x, float* dist_table)
+            const {};
 
     IndexIVF();
 };

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -11,7 +11,6 @@
 
 #include <omp.h>
 
-
 #include <cinttypes>
 #include <cstdio>
 

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -59,10 +59,10 @@ void IndexScalarQuantizer::search(
     FAISS_THROW_IF_NOT(
             metric_type == METRIC_L2 || metric_type == METRIC_INNER_PRODUCT);
 
-// Adding an openMP guard here to spawn threads only if n > 1, where n is the number
-// of queries in the batch. If n = 1, then the search is done in a single thread.
-// This is done to avoid the overhead of spawning threads for executing sequential code.
-// This is for bleve, more in: MB-61930
+// Adding an openMP guard here to spawn threads only if n > 1, where n is the
+// number of queries in the batch. If n = 1, then the search is done in a single
+// thread. This is done to avoid the overhead of spawning threads for executing
+// sequential code. This is for bleve, more in: MB-61930
 #pragma omp parallel if (n > 1) num_threads(num_omp_threads)
     {
         std::unique_ptr<InvertedListScanner> scanner(
@@ -290,9 +290,8 @@ void IndexIVFScalarQuantizer::compute_distance_to_codes_for_list(
         const uint8_t* codes,
         float* dists,
         float* dist_table) const {
-
     std::unique_ptr<ScalarQuantizer::SQDistanceComputer> dc(
-        sq.get_distance_computer(metric_type));
+            sq.get_distance_computer(metric_type));
 
     dc->code_size = sq.code_size;
 
@@ -309,6 +308,5 @@ void IndexIVFScalarQuantizer::compute_distance_to_codes_for_list(
 
     return;
 }
-
 
 } // namespace faiss

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -135,38 +135,38 @@ IndexIVFScalarQuantizer::IndexIVFScalarQuantizer(
     is_trained = false;
 }
 
-void IndexIVFScalarQuantizer::dist_compute(const float* query, const idx_t* ids, size_t n_ids, float* dists) const {
+void IndexIVFScalarQuantizer::dist_compute(
+        const float* query,
+        const idx_t* ids,
+        size_t n_ids,
+        float* dists) const {
     // Get the distance computer
-    std::unique_ptr<ScalarQuantizer::SQDistanceComputer> dc(sq.get_distance_computer(metric_type));
+    std::unique_ptr<ScalarQuantizer::SQDistanceComputer> dc(
+            sq.get_distance_computer(metric_type));
     dc->code_size = sq.code_size;
-    
-    std::vector<float> tmp(d);
 
-    // Set up the query
-    if (by_residual) {
-        // If using residuals, we'll compute residuals for each list_no
-       
-        dc->set_query(query); // Will be overridden for each list_no
-    } else {
+    // Set up the query if not using residuals
+    if (!by_residual) {
         dc->set_query(query);
     }
-    
+
     // Process each ID
     for (size_t i = 0; i < n_ids; i++) {
         idx_t id = ids[i];
         idx_t lo = direct_map.get(id);
         idx_t list_no = lo_listno(lo);
         idx_t offset = lo_offset(lo);
-        
+
         // Get the code for the vector
         const uint8_t* code = invlists->get_single_code(list_no, offset);
-        
+
         if (by_residual) {
             // Compute residual for this list_no
+            std::vector<float> tmp(d);
             quantizer->compute_residual(query, tmp.data(), list_no);
             dc->set_query(tmp.data());
         }
-        
+
         // Compute the distance
         dists[i] = dc->query_to_code(code);
     }

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -65,7 +65,6 @@ struct IndexScalarQuantizer : IndexFlatCodes {
 
 struct IndexIVFScalarQuantizer : IndexIVF {
     ScalarQuantizer sq;
-    bool by_residual;
 
     IndexIVFScalarQuantizer(
             Index* quantizer,
@@ -100,31 +99,21 @@ struct IndexIVFScalarQuantizer : IndexIVF {
             const IDSelector* sel,
             const IVFSearchParameters* params) const override;
 
-    void reconstruct_from_offset(
-            int64_t list_no,
-            int64_t offset,
-            float* recons) const override;
+    void reconstruct_from_offset(int64_t list_no, int64_t offset, float* recons) const override;
 
     void compute_distance_to_codes_for_list(
-            const idx_t list_no,
-            const float* x,
-            idx_t n,
-            const uint8_t* codes,
-            float* dists,
-            float* dist_table) const override;
+    	const idx_t list_no,
+        const float* x,
+        idx_t n,
+        const uint8_t* codes,
+        float* dists,
+        float* dist_table) const override;
 
     void dist_compute(const float* query, const idx_t* ids, size_t n_ids, float* dists) const;
 
     /* standalone codec interface */
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
 
-    void compute_distance_to_codes_for_list(
-            const idx_t list_no,
-            const float* x,
-            idx_t n,
-            const uint8_t* codes,
-            float* dists,
-            float* dist_table) const override;
 };
 
 } // namespace faiss

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -105,15 +105,13 @@ struct IndexIVFScalarQuantizer : IndexIVF {
     /* standalone codec interface */
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
 
-
     void compute_distance_to_codes_for_list(
-        const idx_t list_no,
-        const float* x,
-        idx_t n,
-        const uint8_t* codes,
-        float* dists,
-        float* dist_table) const override;
-
+            const idx_t list_no,
+            const float* x,
+            idx_t n,
+            const uint8_t* codes,
+            float* dists,
+            float* dist_table) const override;
 };
 
 } // namespace faiss

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -65,6 +65,7 @@ struct IndexScalarQuantizer : IndexFlatCodes {
 
 struct IndexIVFScalarQuantizer : IndexIVF {
     ScalarQuantizer sq;
+    bool by_residual;
 
     IndexIVFScalarQuantizer(
             Index* quantizer,
@@ -99,8 +100,20 @@ struct IndexIVFScalarQuantizer : IndexIVF {
             const IDSelector* sel,
             const IVFSearchParameters* params) const override;
 
-    void reconstruct_from_offset(int64_t list_no, int64_t offset, float* recons)
-            const override;
+    void reconstruct_from_offset(
+            int64_t list_no,
+            int64_t offset,
+            float* recons) const override;
+
+    void compute_distance_to_codes_for_list(
+            const idx_t list_no,
+            const float* x,
+            idx_t n,
+            const uint8_t* codes,
+            float* dists,
+            float* dist_table) const override;
+
+    void dist_compute(const float* query, const idx_t* ids, size_t n_ids, float* dists) const;
 
     /* standalone codec interface */
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;

--- a/faiss/OMPConfig.cpp
+++ b/faiss/OMPConfig.cpp
@@ -7,14 +7,13 @@
 
 // -*- c++ -*-
 
-
 #include <faiss/OMPConfig.h>
 
 namespace faiss {
 
-    unsigned int num_omp_threads = std::thread::hardware_concurrency();
+unsigned int num_omp_threads = std::thread::hardware_concurrency();
 
-    void set_num_omp_threads(unsigned int value) {
-        num_omp_threads = value;
-    }
+void set_num_omp_threads(unsigned int value) {
+    num_omp_threads = value;
 }
+} // namespace faiss

--- a/faiss/OMPConfig.h
+++ b/faiss/OMPConfig.h
@@ -9,7 +9,7 @@
 
 #ifndef OMPCONFIG_H
 #define OMPCONFIG_H
-
+#include <iostream>
 #include <thread>
 
 namespace faiss {

--- a/faiss/OMPConfig.h
+++ b/faiss/OMPConfig.h
@@ -9,7 +9,7 @@
 
 #ifndef OMPCONFIG_H
 #define OMPCONFIG_H
-#include <iostream>
+
 #include <thread>
 
 namespace faiss {

--- a/faiss/OMPConfig.h
+++ b/faiss/OMPConfig.h
@@ -13,39 +13,41 @@
 #include <thread>
 
 namespace faiss {
-    // Degree of OpenMP concurrency, determining the number of threads
-    // used in OpenMP parallel regions.
-    //
-    // This variable specifies the number of threads to be employed in
-    // parallel regions defined by OpenMP directives. If not set explicitly,
-    // the default value is the number of hardware threads available on
-    // the system. This allows for efficient utilization of available
-    // processing resources.
-    //
-    // The value of num_omp_threads can be modified to control the level
-    // of parallelism and optimize performance based on the specific
-    // requirements and characteristics of the workload.
-    //
-    // Usage:
-    // - Setting num_omp_threads to a specific value before entering an
-    //   OpenMP parallel region will limit or expand the number of threads
-    //   accordingly.
-    // - If num_omp_threads is not set, OpenMP will automatically use the
-    //   number of hardware threads as the default value.
-    //
-    // Example:
-    // unsigned int num_omp_threads = 4; // Use 4 threads in OpenMP parallel regions.
-    extern unsigned int num_omp_threads;
+// Degree of OpenMP concurrency, determining the number of threads
+// used in OpenMP parallel regions.
+//
+// This variable specifies the number of threads to be employed in
+// parallel regions defined by OpenMP directives. If not set explicitly,
+// the default value is the number of hardware threads available on
+// the system. This allows for efficient utilization of available
+// processing resources.
+//
+// The value of num_omp_threads can be modified to control the level
+// of parallelism and optimize performance based on the specific
+// requirements and characteristics of the workload.
+//
+// Usage:
+// - Setting num_omp_threads to a specific value before entering an
+//   OpenMP parallel region will limit or expand the number of threads
+//   accordingly.
+// - If num_omp_threads is not set, OpenMP will automatically use the
+//   number of hardware threads as the default value.
+//
+// Example:
+// unsigned int num_omp_threads = 4; // Use 4 threads in OpenMP parallel
+// regions.
+extern unsigned int num_omp_threads;
 
-    // Setter function for num_omp_threads.
-    //
-    // Parameters:
-    // - value: The desired number of threads to be used in OpenMP parallel regions.
-    //
-    // Usage:
-    // set_num_omp_threads(8); // would set to use 8 threads in OpenMP parallel regions.
-    //
-    // p.s. to be invoked on process init only.
-    void set_num_omp_threads(unsigned int value);
-}
+// Setter function for num_omp_threads.
+//
+// Parameters:
+// - value: The desired number of threads to be used in OpenMP parallel regions.
+//
+// Usage:
+// set_num_omp_threads(8); // would set to use 8 threads in OpenMP parallel
+// regions.
+//
+// p.s. to be invoked on process init only.
+void set_num_omp_threads(unsigned int value);
+} // namespace faiss
 #endif // OMPCONFIG_H

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -15,7 +15,6 @@
 #include <faiss/impl/platform_macros.h>
 #include <omp.h>
 
-
 #ifdef __SSE__
 #include <immintrin.h>
 #endif
@@ -2121,7 +2120,10 @@ SQDistanceComputer* ScalarQuantizer::get_distance_computer(
     }
 }
 
-void SQDistanceComputer::distance_to_codes(idx_t n, const uint8_t* codes, float* dists) {
+void SQDistanceComputer::distance_to_codes(
+        idx_t n,
+        const uint8_t* codes,
+        float* dists) {
     for (idx_t i = 0; i < n; i++) {
         const uint8_t* code = codes + i * code_size;
         dists[i] = query_to_code(code);

--- a/faiss/impl/ScalarQuantizer.h
+++ b/faiss/impl/ScalarQuantizer.h
@@ -108,7 +108,7 @@ struct ScalarQuantizer : Quantizer {
             return query_to_code(code);
         }
 
-	void distance_to_codes(idx_t n, const uint8_t* codes, float* dists);
+        void distance_to_codes(idx_t n, const uint8_t* codes, float* dists);
     };
 
     SQDistanceComputer* get_distance_computer(

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -8,9 +8,9 @@
 #pragma once
 
 // basic int types and size_t
+#include <faiss/OMPConfig.h>
 #include <cstdint>
 #include <cstdio>
-#include <faiss/OMPConfig.h>
 
 #ifdef _WIN32
 

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -943,6 +943,10 @@ IndexBinary* index_binary_factory(int d, const char* description) {
     } else if (sscanf(description, "BHash%d", &b) == 1) {
         index = new IndexBinaryHash(d, b);
 
+    } else if (strcmp(description, "IDMap,BFlat") == 0) {
+        auto* flat = new faiss::IndexBinaryFlat(d);
+        index = new faiss::IndexBinaryIDMap(flat);
+
     } else if (std::string(description) == "BFlat") {
         index = new IndexBinaryFlat(d);
 

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -943,9 +943,9 @@ IndexBinary* index_binary_factory(int d, const char* description) {
     } else if (sscanf(description, "BHash%d", &b) == 1) {
         index = new IndexBinaryHash(d, b);
 
-    } else if (strcmp(description, "IDMap,BFlat") == 0) {
+    } else if (strcmp(description, "IDMap2,BFlat") == 0) {
         auto* flat = new faiss::IndexBinaryFlat(d);
-        index = new faiss::IndexBinaryIDMap(flat);
+        index = new faiss::IndexBinaryIDMap2(flat);
 
     } else if (std::string(description) == "BFlat") {
         index = new IndexBinaryFlat(d);


### PR DESCRIPTION
1. Utilities to read and write binary vector indexes to/from buffers.
2. Added selectors to enable filtering for BIVF indexes and modified the BinaryInvertedListScanner constructor to include a selector, to enable that.
4. Added function to the C API to set the direct map for binary index.
5. Added function to compute the distance between the query and the code in the index.
6. Extended the C API to fetch BIVF-specific params like nprobe, nlist, etc.
7. Extend index binary factory to accommodate IDMap, BFlat indexes.