### PR TITLE
Consistent code formatting. 

### DIFF
--- a/c_api/IndexIVF_c_ex.cpp
+++ b/c_api/IndexIVF_c_ex.cpp
@@ -38,16 +38,21 @@ int faiss_Search_closest_eligible_centroids(
         FaissIndex* index,
         idx_t n,
         const float* query,
-        idx_t k, 
+        idx_t k,
         float* centroid_distances,
         idx_t* centroid_ids,
         const FaissSearchParameters* params) {
     try {
-        faiss::IndexIVF* index_ivf = reinterpret_cast<IndexIVF*>(index); 
+        faiss::IndexIVF* index_ivf = reinterpret_cast<IndexIVF*>(index);
         assert(index_ivf);
 
-        index_ivf->quantizer->search(n, query, k, centroid_distances, centroid_ids,
-            reinterpret_cast<const faiss::SearchParameters*>(params));
+        index_ivf->quantizer->search(
+                n,
+                query,
+                k,
+                centroid_distances,
+                centroid_ids,
+                reinterpret_cast<const faiss::SearchParameters*>(params));
     }
     CATCH_AND_HANDLE
 }
@@ -58,7 +63,8 @@ int faiss_get_lists_for_keys(
         size_t n_keys,
         idx_t* lists) {
     try {
-        reinterpret_cast<IndexIVF*>(index)->get_lists_for_keys(keys, n_keys, lists);
+        reinterpret_cast<IndexIVF*>(index)->get_lists_for_keys(
+                keys, n_keys, lists);
     }
     CATCH_AND_HANDLE
 }
@@ -76,7 +82,14 @@ int faiss_IndexIVF_search_preassigned_with_params(
         const FaissSearchParametersIVF* params) {
     try {
         reinterpret_cast<const IndexIVF*>(index)->search_preassigned(
-                n, x, k, assign, centroid_dis, distances, labels, store_pairs,
+                n,
+                x,
+                k,
+                assign,
+                centroid_dis,
+                distances,
+                labels,
+                store_pairs,
                 reinterpret_cast<const faiss::SearchParametersIVF*>(params));
     }
     CATCH_AND_HANDLE
@@ -92,7 +105,7 @@ int faiss_IndexIVF_compute_distance_to_codes_for_list(
         float* dist_table) {
     try {
         reinterpret_cast<IndexIVF*>(index)->compute_distance_to_codes_for_list(
-               list_no, x, n, codes, dists, dist_table);
+                list_no, x, n, codes, dists, dist_table);
         return 0;
     }
     CATCH_AND_HANDLE
@@ -104,7 +117,7 @@ int faiss_IndexIVF_compute_distance_table(
         float* dist_table) {
     try {
         reinterpret_cast<IndexIVF*>(index)->compute_distance_table(
-               x, dist_table);
+                x, dist_table);
         return 0;
     }
     CATCH_AND_HANDLE

--- a/c_api/IndexIVF_c_ex.h
+++ b/c_api/IndexIVF_c_ex.h
@@ -12,16 +12,14 @@
 #define FAISS_INDEX_IVF_EX_C_H
 
 #include "Clustering_c.h"
+#include "IndexIVF_c.h"
 #include "Index_c.h"
 #include "faiss_c.h"
-#include "IndexIVF_c.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-int faiss_IndexIVF_set_direct_map(
-        FaissIndexIVF* index,
-        int direct_map_type);
+int faiss_IndexIVF_set_direct_map(FaissIndexIVF* index, int direct_map_type);
 
 int faiss_SearchParametersIVF_new_with_sel(
         FaissSearchParametersIVF** p_sp,
@@ -33,7 +31,7 @@ int faiss_SearchParametersIVF_new_with_sel(
     @param query: query vector.
     @param k: count of closest number of vectors.
     @param centroid_distances: output distances, size n * k.
-    @param centroid_ids: output centroid IDs, size n * k.    
+    @param centroid_ids: output centroid IDs, size n * k.
 */
 int faiss_Search_closest_eligible_centroids(
         FaissIndex* index,
@@ -42,17 +40,16 @@ int faiss_Search_closest_eligible_centroids(
         idx_t k,
         float* centroid_distances,
         idx_t* centroid_ids,
-        const FaissSearchParameters* params
-);
+        const FaissSearchParameters* params);
 
 /*
     Search the clusters whose IDs are in 'assign' and
-    return the 'k' nearest neighbours from among them.     
+    return the 'k' nearest neighbours from among them.
 
     @param n: number of queries.
     @param x: query vector, size n * d.
     @param k: count of nearest neighbours to be returned for each query.
-    @param centroid_ids: output centroid IDs, size n * k. 
+    @param centroid_ids: output centroid IDs, size n * k.
     @param distance: output distances, size n * k
     @param labels: output labels, size n * k
 */
@@ -94,18 +91,19 @@ int faiss_IndexIVF_compute_distance_to_codes_for_list(
         float* dist_table);
 
 /*
-    Given multiple vector IDs, retrieve the corresponding list (cluster) IDs  
-    from an IVF index. This function efficiently assigns vector IDs to their  
-    respective inverted lists/clusters in a batch operation.  
+    Given multiple vector IDs, retrieve the corresponding list (cluster) IDs
+    from an IVF index. This function efficiently assigns vector IDs to their
+    respective inverted lists/clusters in a batch operation.
 
-    @param index  - Pointer to the Faiss IVF index  
-    @param keys   - Input array of vector IDs (keys)  
-    @param n_keys - Number of vector keys in the input array  
-    @param lists  - Output array where corresponding cluster (list) IDs are stored  
+    @param index  - Pointer to the Faiss IVF index
+    @param keys   - Input array of vector IDs (keys)
+    @param n_keys - Number of vector keys in the input array
+    @param lists  - Output array where corresponding cluster (list) IDs are
+   stored
 */
 
 int faiss_get_lists_for_keys(
-        FaissIndexIVF* index, 
+        FaissIndexIVF* index,
         idx_t* keys,
         size_t n_keys,
         idx_t* lists);

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -9,8 +9,8 @@
 
 #include "Index_c.h"
 #include <faiss/Index.h>
-#include <faiss/impl/IDSelector.h>
 #include <faiss/OMPConfig.h>
+#include <faiss/impl/IDSelector.h>
 #include "macros_impl.h"
 
 extern "C" {
@@ -226,5 +226,4 @@ int faiss_Index_sa_decode(
 void faiss_set_omp_threads(unsigned int n) {
     faiss::set_num_omp_threads(n);
 }
-
 }

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -14,15 +14,22 @@
 
 extern "C" {
 
-int faiss_Index_reconstruct_batch(const FaissIndex* index, idx_t n, const idx_t* keys, float* recons) {
+int faiss_Index_reconstruct_batch(
+        const FaissIndex* index,
+        idx_t n,
+        const idx_t* keys,
+        float* recons) {
     try {
-        reinterpret_cast<const faiss::Index*>(index)->reconstruct_batch(n, keys, recons);
+        reinterpret_cast<const faiss::Index*>(index)->reconstruct_batch(
+                n, keys, recons);
     }
     CATCH_AND_HANDLE
 }
 
-
-int faiss_Index_merge_from(FaissIndex* index, FaissIndex* other, const idx_t add_id) {
+int faiss_Index_merge_from(
+        FaissIndex* index,
+        FaissIndex* other,
+        const idx_t add_id) {
     try {
         reinterpret_cast<faiss::Index*>(index)->merge_from(
                 *reinterpret_cast<faiss::Index*>(other), add_id);
@@ -35,5 +42,4 @@ size_t faiss_Index_size(FaissIndex* index) {
     size_t rv = sizeof(xIndex);
     return rv;
 }
-
 }

--- a/c_api/Index_c_ex.h
+++ b/c_api/Index_c_ex.h
@@ -13,17 +13,18 @@
 
 #include <stddef.h>
 #include <stdio.h>
-#include "faiss_c.h"
 #include "Index_c.h"
-
+#include "faiss_c.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int faiss_Index_reconstruct_batch(const FaissIndex* index, idx_t n,
-        const idx_t* keys, float* recons);
-
+int faiss_Index_reconstruct_batch(
+        const FaissIndex* index,
+        idx_t n,
+        const idx_t* keys,
+        float* recons);
 
 int faiss_Index_merge_from(FaissIndex* index, FaissIndex* other, idx_t add_id);
 

--- a/c_api/index_io_c.cpp
+++ b/c_api/index_io_c.cpp
@@ -9,8 +9,8 @@
 // I/O code for indexes
 
 #include "index_io_c.h"
-#include <faiss/index_io.h>
 #include <faiss/impl/io.h>
+#include <faiss/index_io.h>
 #include "macros_impl.h"
 
 using faiss::Index;

--- a/c_api/index_io_c_ex.cpp
+++ b/c_api/index_io_c_ex.cpp
@@ -10,8 +10,8 @@
 // More I/O code for indexes
 
 #include "index_io_c_ex.h"
-#include <faiss/index_io.h>
 #include <faiss/impl/io.h>
+#include <faiss/index_io.h>
 #include "macros_impl.h"
 
 using faiss::Index;
@@ -21,7 +21,8 @@ int faiss_write_index_buf(const FaissIndex* idx, size_t* size, uint8_t** buf) {
     try {
         faiss::VectorIOWriter writer;
         faiss::write_index(reinterpret_cast<const Index*>(idx), &writer);
-        uint8_t* tempBuf = (uint8_t*)malloc((writer.data.size()) * sizeof(uint8_t));
+        uint8_t* tempBuf =
+                (uint8_t*)malloc((writer.data.size()) * sizeof(uint8_t));
         std::copy(writer.data.begin(), writer.data.end(), tempBuf);
         *buf = tempBuf;
         *size = writer.data.size();
@@ -30,7 +31,11 @@ int faiss_write_index_buf(const FaissIndex* idx, size_t* size, uint8_t** buf) {
     CATCH_AND_HANDLE
 }
 
-int faiss_read_index_buf(const uint8_t* buf, size_t size, int io_flags, FaissIndex** p_out) {
+int faiss_read_index_buf(
+        const uint8_t* buf,
+        size_t size,
+        int io_flags,
+        FaissIndex** p_out) {
     try {
         faiss::BufIOReader reader;
         reader.buf = buf;

--- a/c_api/index_io_c_ex.h
+++ b/c_api/index_io_c_ex.h
@@ -24,18 +24,24 @@ extern "C" {
 // skip prefetch phase while searching over the inverted lists
 #define FAISS_IO_FLAG_SKIP_PREFETCH 32
 // the following two macros together decide whether to read the index from an
-// already mmap'd data buffer. it's C equivalent of IO_FLAG_READ_MMAP from index_io.h
-// usage is - FAISS_IO_FLAG_READ_MMAP | FAISS_IO_FLAG_ONDISK_IVF
+// already mmap'd data buffer. it's C equivalent of IO_FLAG_READ_MMAP from
+// index_io.h usage is - FAISS_IO_FLAG_READ_MMAP | FAISS_IO_FLAG_ONDISK_IVF
 #define FAISS_IO_FLAG_READ_MMAP 64
 #define FAISS_IO_FLAG_ONDISK_IVF 0x646f0000
 
 /** Write index to buffer
  */
-int faiss_write_index_buf(const FaissIndex* idx, size_t* buf_size, uint8_t** buf);
+int faiss_write_index_buf(
+        const FaissIndex* idx,
+        size_t* buf_size,
+        uint8_t** buf);
 
 /** Read index from buffer
  */
-int faiss_read_index_buf(const uint8_t* buf, size_t limit, int io_flags,
+int faiss_read_index_buf(
+        const uint8_t* buf,
+        size_t limit,
+        int io_flags,
         FaissIndex** p_out);
 
 void faiss_free_buf(uint8_t** buf);

--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -17,8 +17,8 @@
 #include <cstdio>
 #include <cstring>
 
-#include <omp.h>
 #include <faiss/OMPConfig.h>
+#include <omp.h>
 
 #include <faiss/IndexFlat.h>
 #include <faiss/impl/FaissAssert.h>

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -453,7 +453,8 @@ void IndexIVF::search_preassigned(
     void* inverted_list_context =
             params ? params->inverted_list_context : nullptr;
 
-#pragma omp parallel if (do_parallel) reduction(+ : nlistv, ndis, nheap) num_threads(num_omp_threads)
+#pragma omp parallel if (do_parallel) reduction(+ : nlistv, ndis, nheap) \
+        num_threads(num_omp_threads)
     {
         std::unique_ptr<InvertedListScanner> scanner(
                 get_InvertedListScanner(store_pairs, sel, params));
@@ -793,7 +794,8 @@ void IndexIVF::range_search_preassigned(
     void* inverted_list_context =
             params ? params->inverted_list_context : nullptr;
 
-#pragma omp parallel if (do_parallel) reduction(+ : nlistv, ndis) num_threads(num_omp_threads)
+#pragma omp parallel if (do_parallel) reduction(+ : nlistv, ndis) \
+        num_threads(num_omp_threads)
     {
         RangeSearchPartialResult pres(result);
         std::unique_ptr<InvertedListScanner> scanner(

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -449,7 +449,6 @@ struct IndexIVF : Index, IndexIVFInterface {
      */
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
 
-
     /** Given a query vector x, compute distance to provided codes
      * for the input list_no. This is a special purpose method
      * to be used as a flat distance computer for an inverted
@@ -466,12 +465,12 @@ struct IndexIVF : Index, IndexIVFInterface {
      */
 
     virtual void compute_distance_to_codes_for_list(
-        const idx_t list_no,
-        const float* x,
-        idx_t n,
-        const uint8_t* codes,
-        float* dists,
-        float* dist_table) const {};
+            const idx_t list_no,
+            const float* x,
+            idx_t n,
+            const uint8_t* codes,
+            float* dists,
+            float* dist_table) const {};
 
     /** Given a query vector x, compute distance table and
      *  return to the caller.
@@ -481,10 +480,8 @@ struct IndexIVF : Index, IndexIVFInterface {
      *
      */
 
-    virtual void compute_distance_table(
-        const float* x,
-        float* dist_table) const {};
-
+    virtual void compute_distance_table(const float* x, float* dist_table)
+            const {};
 
     IndexIVF();
 };

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -11,7 +11,6 @@
 
 #include <omp.h>
 
-
 #include <cinttypes>
 #include <cstdio>
 

--- a/faiss/OMPConfig.cpp
+++ b/faiss/OMPConfig.cpp
@@ -7,14 +7,13 @@
 
 // -*- c++ -*-
 
-
 #include <faiss/OMPConfig.h>
 
 namespace faiss {
 
-    unsigned int num_omp_threads = std::thread::hardware_concurrency();
+unsigned int num_omp_threads = std::thread::hardware_concurrency();
 
-    void set_num_omp_threads(unsigned int value) {
-        num_omp_threads = value;
-    }
+void set_num_omp_threads(unsigned int value) {
+    num_omp_threads = value;
 }
+} // namespace faiss

--- a/faiss/OMPConfig.h
+++ b/faiss/OMPConfig.h
@@ -13,39 +13,41 @@
 #include <thread>
 
 namespace faiss {
-    // Degree of OpenMP concurrency, determining the number of threads
-    // used in OpenMP parallel regions.
-    //
-    // This variable specifies the number of threads to be employed in
-    // parallel regions defined by OpenMP directives. If not set explicitly,
-    // the default value is the number of hardware threads available on
-    // the system. This allows for efficient utilization of available
-    // processing resources.
-    //
-    // The value of num_omp_threads can be modified to control the level
-    // of parallelism and optimize performance based on the specific
-    // requirements and characteristics of the workload.
-    //
-    // Usage:
-    // - Setting num_omp_threads to a specific value before entering an
-    //   OpenMP parallel region will limit or expand the number of threads
-    //   accordingly.
-    // - If num_omp_threads is not set, OpenMP will automatically use the
-    //   number of hardware threads as the default value.
-    //
-    // Example:
-    // unsigned int num_omp_threads = 4; // Use 4 threads in OpenMP parallel regions.
-    extern unsigned int num_omp_threads;
+// Degree of OpenMP concurrency, determining the number of threads
+// used in OpenMP parallel regions.
+//
+// This variable specifies the number of threads to be employed in
+// parallel regions defined by OpenMP directives. If not set explicitly,
+// the default value is the number of hardware threads available on
+// the system. This allows for efficient utilization of available
+// processing resources.
+//
+// The value of num_omp_threads can be modified to control the level
+// of parallelism and optimize performance based on the specific
+// requirements and characteristics of the workload.
+//
+// Usage:
+// - Setting num_omp_threads to a specific value before entering an
+//   OpenMP parallel region will limit or expand the number of threads
+//   accordingly.
+// - If num_omp_threads is not set, OpenMP will automatically use the
+//   number of hardware threads as the default value.
+//
+// Example:
+// unsigned int num_omp_threads = 4; // Use 4 threads in OpenMP parallel
+// regions.
+extern unsigned int num_omp_threads;
 
-    // Setter function for num_omp_threads.
-    //
-    // Parameters:
-    // - value: The desired number of threads to be used in OpenMP parallel regions.
-    //
-    // Usage:
-    // set_num_omp_threads(8); // would set to use 8 threads in OpenMP parallel regions.
-    //
-    // p.s. to be invoked on process init only.
-    void set_num_omp_threads(unsigned int value);
-}
+// Setter function for num_omp_threads.
+//
+// Parameters:
+// - value: The desired number of threads to be used in OpenMP parallel regions.
+//
+// Usage:
+// set_num_omp_threads(8); // would set to use 8 threads in OpenMP parallel
+// regions.
+//
+// p.s. to be invoked on process init only.
+void set_num_omp_threads(unsigned int value);
+} // namespace faiss
 #endif // OMPCONFIG_H

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -15,7 +15,6 @@
 #include <faiss/impl/platform_macros.h>
 #include <omp.h>
 
-
 #ifdef __SSE__
 #include <immintrin.h>
 #endif
@@ -2121,7 +2120,10 @@ SQDistanceComputer* ScalarQuantizer::get_distance_computer(
     }
 }
 
-void SQDistanceComputer::distance_to_codes(idx_t n, const uint8_t* codes, float* dists) {
+void SQDistanceComputer::distance_to_codes(
+        idx_t n,
+        const uint8_t* codes,
+        float* dists) {
     for (idx_t i = 0; i < n; i++) {
         const uint8_t* code = codes + i * code_size;
         dists[i] = query_to_code(code);

--- a/faiss/impl/ScalarQuantizer.h
+++ b/faiss/impl/ScalarQuantizer.h
@@ -108,7 +108,7 @@ struct ScalarQuantizer : Quantizer {
             return query_to_code(code);
         }
 
-	void distance_to_codes(idx_t n, const uint8_t* codes, float* dists);
+        void distance_to_codes(idx_t n, const uint8_t* codes, float* dists);
     };
 
     SQDistanceComputer* get_distance_computer(

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -8,9 +8,9 @@
 #pragma once
 
 // basic int types and size_t
+#include <faiss/OMPConfig.h>
 #include <cstdint>
 #include <cstdio>
-#include <faiss/OMPConfig.h>
 
 #ifdef _WIN32
 


### PR DESCRIPTION
Run clang-format to enforce consistent formatting in the files changed.