### PR TITLE
Fix CMake Defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,10 @@ set(CMAKE_CXX_STANDARD 17)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # Valid values are "generic", "avx2", "avx512", "avx512_spr", "sve".
-option(FAISS_OPT_LEVEL "" "generic")
+# Valid values are "generic", "avx2", "avx512", "avx512_spr", "sve".
+if(NOT DEFINED FAISS_OPT_LEVEL)
+  set(FAISS_OPT_LEVEL "generic" CACHE STRING "Optimization level (generic, avx2, avx512, etc.)")
+endif()
 option(FAISS_ENABLE_GPU "Enable support for GPU indexes." ON)
 option(FAISS_GPU_STATIC "Link GPU libraries statically." OFF)
 option(FAISS_ENABLE_CUVS "Enable cuVS for GPU indexes." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,6 @@ set(CMAKE_CXX_STANDARD 17)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # Valid values are "generic", "avx2", "avx512", "avx512_spr", "sve".
-# Valid values are "generic", "avx2", "avx512", "avx512_spr", "sve".
 if(NOT DEFINED FAISS_OPT_LEVEL)
   set(FAISS_OPT_LEVEL "generic" CACHE STRING "Optimization level (generic, avx2, avx512, etc.)")
 endif()


### PR DESCRIPTION
- If optimization level is not specified, force usage of "generic"