### PR TITLE
MB-71216: Implement fast merge for `IndexBinaryIVF` and `IndexFlatCodes` classes

### DIFF
--- a/c_api/IndexBinaryIVF_c_ex.cpp
+++ b/c_api/IndexBinaryIVF_c_ex.cpp
@@ -100,4 +100,22 @@ int faiss_IndexBinaryIVF_get_centroids_and_cardinality(
     }
     CATCH_AND_HANDLE
 }
+
+int faiss_Set_quantizers_binary(FaissIndexBinary* target, FaissIndexBinary* source) {
+    try {
+        auto* tgt = reinterpret_cast<faiss::IndexBinary*>(target);
+        auto* src = reinterpret_cast<faiss::IndexBinary*>(source);
+        assert(tgt && src);
+
+        if (auto* tgt_bivf = dynamic_cast<faiss::IndexBinaryIVF*>(tgt)) {
+            auto* src_bivf = dynamic_cast<faiss::IndexBinaryIVF*>(src);
+            assert(src_bivf);
+
+            tgt_bivf->quantizer = src_bivf->quantizer;
+            tgt_bivf->is_trained = true;
+            return 0;
+        }
+    }
+    CATCH_AND_HANDLE
+}
 }

--- a/c_api/IndexBinaryIVF_c_ex.h
+++ b/c_api/IndexBinaryIVF_c_ex.h
@@ -77,6 +77,8 @@ int faiss_IndexBinaryIVF_get_centroids_and_cardinality(
         size_t* cardinalities,
         idx_t* centroid_ids);
 
+int faiss_Set_quantizers_binary(FaissIndexBinary* target, FaissIndexBinary* source);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c_api/IndexIVF_c_ex.cpp
+++ b/c_api/IndexIVF_c_ex.cpp
@@ -11,6 +11,7 @@
 #include <faiss/IndexIVF.h>
 #include <faiss/IndexScalarQuantizer.h>
 #include <faiss/IndexIVFRaBitQ.h>
+#include <faiss/IndexBinaryIVF.h>
 #include <faiss/clone_index.h>
 #include "macros_impl.h"
 
@@ -75,6 +76,16 @@ int faiss_Set_quantizers(FaissIndex* target, FaissIndex* source) {
             tgt_ivfsq->quantizer = src_ivfsq->quantizer;
             tgt_ivfsq->is_trained = true;
             tgt_ivfsq->sq = src_ivfsq->sq;
+            return 0;
+        }
+
+        // --------- IndexSQ ---------
+        if (auto* tgt_sq = dynamic_cast<faiss::IndexScalarQuantizer*>(tgt)) {
+            auto* src_sq = dynamic_cast<faiss::IndexScalarQuantizer*>(src);
+            assert(src_sq);
+
+            tgt_sq->is_trained = true;
+            tgt_sq->sq = src_sq->sq;
             return 0;
         }
 

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -350,8 +350,12 @@ void IndexBinaryIVF::check_compatible_for_merge(
     FAISS_THROW_IF_NOT(other->d == d);
     FAISS_THROW_IF_NOT(other->nlist == nlist);
     FAISS_THROW_IF_NOT(other->code_size == code_size);
+
+    bool merge_direct_map_cond = (this->direct_map.type == DirectMap::Array &&
+        other->direct_map.type == DirectMap::Array)||
+    (this->direct_map.no() && other->direct_map.no());
     FAISS_THROW_IF_NOT_MSG(
-            direct_map.no() && other->direct_map.no(),
+            merge_direct_map_cond,
             "direct map copy not implemented");
     FAISS_THROW_IF_NOT_MSG(
             typeid(*this) == typeid(*other),

--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -22,7 +22,11 @@ IndexFlatCodes::IndexFlatCodes(size_t code_size, idx_t d, MetricType metric)
 
 IndexFlatCodes::IndexFlatCodes() : code_size(0), codes_ptr(nullptr) {}
 
-IndexFlatCodes::~IndexFlatCodes() {}
+IndexFlatCodes::~IndexFlatCodes() {
+    // always let go for the codes_ptr when exiting faiss to make it safe
+    // to be free'd/GC'd at the application layer
+    codes_ptr = nullptr;
+}
 
 void IndexFlatCodes::add(idx_t n, const float* x) {
     FAISS_THROW_IF_NOT(is_trained);
@@ -100,8 +104,12 @@ void IndexFlatCodes::merge_from(Index& otherIndex, idx_t add_id) {
     check_compatible_for_merge(otherIndex);
     IndexFlatCodes* other = static_cast<IndexFlatCodes*>(&otherIndex);
     codes.resize((ntotal + other->ntotal) * code_size);
+
+    // the SQ8 index maybe be mmaped underneath the hood, so we need to check where
+    // the codes are actually stored before copying
+    uint8_t* src = (other->codes_ptr != nullptr) ? other->codes_ptr : other->codes.data();
     memcpy(codes.data() + (ntotal * code_size),
-           other->codes.data(),
+           src,
            other->ntotal * code_size);
     ntotal += other->ntotal;
     other->reset();

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -26,9 +26,6 @@ struct IndexScalarQuantizer : IndexFlatCodes {
     /// Used to encode the vectors
     ScalarQuantizer sq;
 
-    /// Pointer for mmaped codes if enabled
-    uint8_t* codes_ptr = nullptr;
-
     /** Constructor.
      *
      * @param d      dimensionality of the input vectors


### PR DESCRIPTION
- the `FaissIndexBinary` is a separate construct from `FaissIndex` at the c_api level. So, we'll need to implement the setting of the quantizers separately.
- Implement the merging of the direct maps in merge_from API for `IndexBinaryIVF` class since it inherits from `IndexBinary` and not from `IndexIVF` class
- `IndexScalarQuantizer` inherits the codes_ptr from `IndexFlatCodes` and can use the same for dist_compute APIs, so we can safely cleanup that part of the code. Also, set it to `null` when the destructor is called for a more responsible ref-counting. 