### PR TITLE
MB-71714: Fix error handling in getNumDevices

### DIFF
--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -35,7 +35,7 @@ int getNumDevices() {
         // clear the error status for the current thread
         cudaGetLastError();
     }
-    FAISS_ASSERT(numDev != -1);
+    FAISS_ASSERT(numDev >= 0);
 
     return numDev;
 }

--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -29,10 +29,10 @@ void setCurrentDevice(int device) {
 
 int getNumDevices() {
     int numDev = -1;
-    cudaGetDeviceCount(&numDev);
-    auto lastError = cudaGetLastError();
-    if (lastError != cudaSuccess || numDev < 0) {
+    auto err = cudaGetDeviceCount(&numDev);
+    if (err != cudaSuccess) {
         numDev = 0;
+        cudaGetLastError();
     }
     FAISS_ASSERT(numDev >= 0);
 

--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -29,11 +29,10 @@ void setCurrentDevice(int device) {
 
 int getNumDevices() {
     int numDev = -1;
-    cudaError_t err = cudaGetDeviceCount(&numDev);
-    if (err != cudaSuccess) {
+    cudaGetDeviceCount(&numDev);
+    auto lastError = cudaGetLastError();
+    if (lastError != cudaSuccess || numDev < 0) {
         numDev = 0;
-        // clear the error status for the current thread
-        cudaGetLastError();
     }
     FAISS_ASSERT(numDev >= 0);
 

--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -30,10 +30,8 @@ void setCurrentDevice(int device) {
 int getNumDevices() {
     int numDev = -1;
     cudaError_t err = cudaGetDeviceCount(&numDev);
-    if (cudaErrorNoDevice == err || cudaErrorInsufficientDriver == err) {
+    if (err != cudaSuccess) {
         numDev = 0;
-    } else {
-        CUDA_VERIFY(err);
     }
     FAISS_ASSERT(numDev != -1);
 

--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -32,6 +32,8 @@ int getNumDevices() {
     cudaError_t err = cudaGetDeviceCount(&numDev);
     if (err != cudaSuccess) {
         numDev = 0;
+        // clear the error status for the current thread
+        cudaGetLastError();
     }
     FAISS_ASSERT(numDev != -1);
 

--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -30,7 +30,7 @@ void setCurrentDevice(int device) {
 int getNumDevices() {
     int numDev = -1;
     auto err = cudaGetDeviceCount(&numDev);
-    if (err != cudaSuccess) {
+    if (err != cudaSuccess || numDev < 0) {
         numDev = 0;
         cudaGetLastError();
     }


### PR DESCRIPTION
- During process initialization, we make a call to the `getNumDevices` API to 
  capture the number of available GPUs.
- FAISS currently aborts the process with a status code of `SIGBRT` when the error is 
  not of two specific errors, instead of falling back to setting the number of devices as 0.
- Fix this issue by always falling back to `0` number of devices if the CUDA API returns an 
  error.
