### PR TITLE
MB-71397: Fix API that approximates the size of FAISS indexes

### DIFF
--- a/c_api/IndexBinary_c_ex.cpp
+++ b/c_api/IndexBinary_c_ex.cpp
@@ -60,7 +60,6 @@ int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size) {
             if (ivfQuantizer != nullptr) {
                 size += faiss_index_binary_static_size(ivfQuantizer);
             }
-            // Only include direct_map memory size if present
             if (!ivf->direct_map.no()) {
                 size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
             }

--- a/c_api/IndexBinary_c_ex.cpp
+++ b/c_api/IndexBinary_c_ex.cpp
@@ -37,19 +37,18 @@ int faiss_IndexBinary_search_with_params(
 int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size) {
     try {
         const faiss::IndexBinary* idx = reinterpret_cast<const faiss::IndexBinary*>(index);
-
         // Base: raw binary codes (d / 8 bytes per vector).
         size_t size = (size_t)idx->ntotal * idx->code_size;
-
         // IVF-specific overhead not captured by code_size:
         //   centroids: quantizer->ntotal * quantizer->sa_code_size()
         //   stored IDs: ntotal * sizeof(idx_t)  (per-vector ID in each inverted list)
         if (auto ivf = dynamic_cast<const faiss::IndexBinaryIVF*>(idx)) {
             auto ivfQuantizer = ivf->quantizer;
-            size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
+            if (ivfQuantizer != nullptr) {
+                size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
+            }
             size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
         }
-
         *p_size = size;
     }
     CATCH_AND_HANDLE

--- a/c_api/IndexBinary_c_ex.cpp
+++ b/c_api/IndexBinary_c_ex.cpp
@@ -54,35 +54,15 @@ static size_t faiss_index_binary_static_size(const faiss::IndexBinary* idx) {
 int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size) {
     try {
         const faiss::IndexBinary* idx = reinterpret_cast<const faiss::IndexBinary*>(index);
-        // Base: raw binary codes (d / 8 bytes per vector).
-        size_t size = (size_t)idx->ntotal * idx->code_size;
-        // Static struct footprint
-        size += faiss_index_binary_static_size(idx);
-        // IVF-specific overhead not captured by code_size:
-        //   centroids: quantizer->ntotal * quantizer->sa_code_size()
-        //   stored IDs: ntotal * sizeof(idx_t)  (per-vector ID in each inverted list)
-        //   quantizer struct footprint
+        size_t size = faiss_index_binary_static_size(idx);
         if (auto ivf = dynamic_cast<const faiss::IndexBinaryIVF*>(idx)) {
             auto ivfQuantizer = ivf->quantizer;
             if (ivfQuantizer != nullptr) {
-                size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
                 size += faiss_index_binary_static_size(ivfQuantizer);
             }
-            size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
-        }
-        *p_size = size;
-    }
-    CATCH_AND_HANDLE
-}
-
-int faiss_IndexBinary_static_size(const FaissIndexBinary* index, size_t* p_size) {
-    try {
-        const faiss::IndexBinary* idx = reinterpret_cast<const faiss::IndexBinary*>(index);
-        size_t size = faiss_index_binary_static_size(idx);
-        // For IVF indices, include quantizer struct footprint
-        if (auto ivf = dynamic_cast<const faiss::IndexBinaryIVF*>(idx)) {
-            if (ivf->quantizer != nullptr) {
-                size += faiss_index_binary_static_size(ivf->quantizer);
+            // Only include direct_map memory size if present
+            if (!ivf->direct_map.no()) {
+                size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
             }
         }
         *p_size = size;

--- a/c_api/IndexBinary_c_ex.cpp
+++ b/c_api/IndexBinary_c_ex.cpp
@@ -51,7 +51,6 @@ int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size) {
         }
 
         *p_size = size;
-        return 0;
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/IndexBinary_c_ex.cpp
+++ b/c_api/IndexBinary_c_ex.cpp
@@ -10,6 +10,7 @@
 
 #include "IndexBinary_c_ex.h"
 #include <faiss/IndexBinary.h>
+#include <faiss/IndexBinaryIVF.h>
 #include "macros_impl.h"
 
 extern "C" {
@@ -33,9 +34,25 @@ int faiss_IndexBinary_search_with_params(
     CATCH_AND_HANDLE
 }
 
-size_t faiss_IndexBinary_size(FaissIndexBinary* index) {
-    auto xIndex = reinterpret_cast<faiss::IndexBinary*>(index);
-    size_t rv = sizeof(xIndex);
-    return rv;
+int faiss_IndexBinary_size(FaissIndexBinary* index, size_t* p_size) {
+    try {
+        const faiss::IndexBinary* idx = reinterpret_cast<const faiss::IndexBinary*>(index);
+
+        // Base: raw binary codes (d / 8 bytes per vector).
+        size_t size = (size_t)idx->ntotal * idx->code_size;
+
+        // IVF-specific overhead not captured by code_size:
+        //   centroids: quantizer->ntotal * quantizer->sa_code_size()
+        //   stored IDs: ntotal * sizeof(idx_t)  (per-vector ID in each inverted list)
+        if (auto ivf = dynamic_cast<const faiss::IndexBinaryIVF*>(idx)) {
+            auto ivfQuantizer = ivf->quantizer;
+            size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
+            size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
+        }
+
+        *p_size = size;
+        return 0;
+    }
+    CATCH_AND_HANDLE
 }
 }

--- a/c_api/IndexBinary_c_ex.cpp
+++ b/c_api/IndexBinary_c_ex.cpp
@@ -10,6 +10,7 @@
 
 #include "IndexBinary_c_ex.h"
 #include <faiss/IndexBinary.h>
+#include <faiss/IndexBinaryFlat.h>
 #include <faiss/IndexBinaryIVF.h>
 #include "macros_impl.h"
 
@@ -39,15 +40,50 @@ int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size) {
         const faiss::IndexBinary* idx = reinterpret_cast<const faiss::IndexBinary*>(index);
         // Base: raw binary codes (d / 8 bytes per vector).
         size_t size = (size_t)idx->ntotal * idx->code_size;
+        // Static struct footprint
+        size += faiss_index_binary_static_size(idx);
         // IVF-specific overhead not captured by code_size:
         //   centroids: quantizer->ntotal * quantizer->sa_code_size()
         //   stored IDs: ntotal * sizeof(idx_t)  (per-vector ID in each inverted list)
+        //   quantizer struct footprint
         if (auto ivf = dynamic_cast<const faiss::IndexBinaryIVF*>(idx)) {
             auto ivfQuantizer = ivf->quantizer;
             if (ivfQuantizer != nullptr) {
                 size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
+                size += faiss_index_binary_static_size(ivfQuantizer);
             }
             size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
+        }
+        *p_size = size;
+    }
+    CATCH_AND_HANDLE
+}
+
+static size_t faiss_index_binary_static_size(const faiss::IndexBinary* idx) {
+    if (idx == nullptr) {
+        return 0;
+    }
+    // BFlat
+    if (dynamic_cast<const faiss::IndexBinaryFlat*>(idx)) {
+        return sizeof(faiss::IndexBinaryFlat);
+    }
+    // BIVF
+    if (dynamic_cast<const faiss::IndexBinaryIVF*>(idx)) {
+        return sizeof(faiss::IndexBinaryIVF);
+    }
+    // Base
+    return sizeof(faiss::IndexBinary);
+}
+
+int faiss_IndexBinary_static_size(const FaissIndexBinary* index, size_t* p_size) {
+    try {
+        const faiss::IndexBinary* idx = reinterpret_cast<const faiss::IndexBinary*>(index);
+        size_t size = faiss_index_binary_static_size(idx);
+        // For IVF indices, include quantizer struct footprint
+        if (auto ivf = dynamic_cast<const faiss::IndexBinaryIVF*>(idx)) {
+            if (ivf->quantizer != nullptr) {
+                size += faiss_index_binary_static_size(ivf->quantizer);
+            }
         }
         *p_size = size;
     }

--- a/c_api/IndexBinary_c_ex.cpp
+++ b/c_api/IndexBinary_c_ex.cpp
@@ -35,6 +35,22 @@ int faiss_IndexBinary_search_with_params(
     CATCH_AND_HANDLE
 }
 
+static size_t faiss_index_binary_static_size(const faiss::IndexBinary* idx) {
+    if (idx == nullptr) {
+        return 0;
+    }
+    // BFlat
+    if (dynamic_cast<const faiss::IndexBinaryFlat*>(idx)) {
+        return sizeof(faiss::IndexBinaryFlat);
+    }
+    // BIVF
+    if (dynamic_cast<const faiss::IndexBinaryIVF*>(idx)) {
+        return sizeof(faiss::IndexBinaryIVF);
+    }
+    // Base
+    return sizeof(faiss::IndexBinary);
+}
+
 int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size) {
     try {
         const faiss::IndexBinary* idx = reinterpret_cast<const faiss::IndexBinary*>(index);
@@ -57,22 +73,6 @@ int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size) {
         *p_size = size;
     }
     CATCH_AND_HANDLE
-}
-
-static size_t faiss_index_binary_static_size(const faiss::IndexBinary* idx) {
-    if (idx == nullptr) {
-        return 0;
-    }
-    // BFlat
-    if (dynamic_cast<const faiss::IndexBinaryFlat*>(idx)) {
-        return sizeof(faiss::IndexBinaryFlat);
-    }
-    // BIVF
-    if (dynamic_cast<const faiss::IndexBinaryIVF*>(idx)) {
-        return sizeof(faiss::IndexBinaryIVF);
-    }
-    // Base
-    return sizeof(faiss::IndexBinary);
 }
 
 int faiss_IndexBinary_static_size(const FaissIndexBinary* index, size_t* p_size) {

--- a/c_api/IndexBinary_c_ex.cpp
+++ b/c_api/IndexBinary_c_ex.cpp
@@ -34,7 +34,7 @@ int faiss_IndexBinary_search_with_params(
     CATCH_AND_HANDLE
 }
 
-int faiss_IndexBinary_size(FaissIndexBinary* index, size_t* p_size) {
+int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size) {
     try {
         const faiss::IndexBinary* idx = reinterpret_cast<const faiss::IndexBinary*>(index);
 

--- a/c_api/IndexBinary_c_ex.h
+++ b/c_api/IndexBinary_c_ex.h
@@ -38,10 +38,8 @@ int faiss_IndexBinary_search_with_params(
         int32_t* distances,
         idx_t* labels);
 
-/** Return an approximate size estimate in bytes for the binary index.
+/** Return an approximate size estimate in bytes for the index.
  * 
- * The estimate accounts for stored codes, the base struct size, and for
- * IVF-based binary indices, includes centroid and stored ID overhead.
  *
  * @param index     opaque pointer to index object
  * @param p_size    output approximate size in bytes

--- a/c_api/IndexBinary_c_ex.h
+++ b/c_api/IndexBinary_c_ex.h
@@ -38,11 +38,16 @@ int faiss_IndexBinary_search_with_params(
         int32_t* distances,
         idx_t* labels);
 
-/** return the size in bytes that the binary index occupies in memory.
- * For IVF-based binary indices, this includes centroid and stored ID overhead.
+/** return an approximate size estimate in bytes for the binary index.
+ * The estimate accounts for stored codes and, for IVF-based binary indices,
+ * includes centroid and stored ID overhead.
+ *
+ * This is not a complete in-memory footprint: it does not attempt to include
+ * all internal allocations such as inverted-list container overhead,
+ * direct_map, or quantizer internals beyond centroid storage.
  *
  * @param index     opaque pointer to index object
- * @param p_size    output size in bytes
+ * @param p_size    output approximate size in bytes
  */
 int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size);
 

--- a/c_api/IndexBinary_c_ex.h
+++ b/c_api/IndexBinary_c_ex.h
@@ -38,11 +38,13 @@ int faiss_IndexBinary_search_with_params(
         int32_t* distances,
         idx_t* labels);
 
-/** return the size of the binary index
- * 
+/** return the size in bytes that the binary index occupies in memory.
+ * For IVF-based binary indices, this includes centroid and stored ID overhead.
+ *
  * @param index     opaque pointer to index object
+ * @param p_size    output size in bytes
  */
-size_t faiss_IndexBinary_size(FaissIndexBinary* index);
+int faiss_IndexBinary_size(FaissIndexBinary* index, size_t* p_size);
 
 #ifdef __cplusplus
 }

--- a/c_api/IndexBinary_c_ex.h
+++ b/c_api/IndexBinary_c_ex.h
@@ -38,18 +38,25 @@ int faiss_IndexBinary_search_with_params(
         int32_t* distances,
         idx_t* labels);
 
-/** return an approximate size estimate in bytes for the binary index.
- * The estimate accounts for stored codes and, for IVF-based binary indices,
- * includes centroid and stored ID overhead.
- *
- * This is not a complete in-memory footprint: it does not attempt to include
- * all internal allocations such as inverted-list container overhead,
- * direct_map, or quantizer internals beyond centroid storage.
+/** Return an approximate size estimate in bytes for the binary index.
+ * 
+ * The estimate accounts for stored codes, the base struct size, and for
+ * IVF-based binary indices, includes centroid and stored ID overhead.
  *
  * @param index     opaque pointer to index object
  * @param p_size    output approximate size in bytes
  */
 int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size);
+
+/** Return the static struct size of the binary index in bytes.
+ *
+ * This returns only the base struct footprint 
+ * without accounting for any stored data
+ *
+ * @param index     opaque pointer to index object
+ * @param p_size    output static size in bytes
+ */
+int faiss_IndexBinary_static_size(const FaissIndexBinary* index, size_t* p_size);
 
 #ifdef __cplusplus
 }

--- a/c_api/IndexBinary_c_ex.h
+++ b/c_api/IndexBinary_c_ex.h
@@ -44,7 +44,7 @@ int faiss_IndexBinary_search_with_params(
  * @param index     opaque pointer to index object
  * @param p_size    output size in bytes
  */
-int faiss_IndexBinary_size(FaissIndexBinary* index, size_t* p_size);
+int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size);
 
 #ifdef __cplusplus
 }

--- a/c_api/IndexBinary_c_ex.h
+++ b/c_api/IndexBinary_c_ex.h
@@ -48,16 +48,6 @@ int faiss_IndexBinary_search_with_params(
  */
 int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size);
 
-/** Return the static struct size of the binary index in bytes.
- *
- * This returns only the base struct footprint 
- * without accounting for any stored data
- *
- * @param index     opaque pointer to index object
- * @param p_size    output static size in bytes
- */
-int faiss_IndexBinary_static_size(const FaissIndexBinary* index, size_t* p_size);
-
 #ifdef __cplusplus
 }
 #endif

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -77,21 +77,16 @@ static size_t faiss_index_static_size(const faiss::Index* idx) {
 int faiss_Index_size(const FaissIndex* index, size_t* p_size) {
     try {
         const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
-        // Base: raw vector codes (works for Flat, SQ, and all other types).
-        size_t size = (size_t)idx->ntotal * idx->sa_code_size();
-        // Static struct footprint
-        size += faiss_index_static_size(idx);
-        // IVF-specific overhead not captured by sa_code_size():
-        //   centroids: quantizer->ntotal * quantizer->sa_code_size()
-        //   stored IDs: ntotal * sizeof(idx_t)  (per-vector ID in each inverted list)
-        //   quantizer struct footprint
+        size_t size = faiss_index_static_size(idx);
         if (auto ivf = dynamic_cast<const faiss::IndexIVF*>(idx)) {
             auto ivfQuantizer = ivf->quantizer;
             if (ivfQuantizer != nullptr) {
-                size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
                 size += faiss_index_static_size(ivfQuantizer);
             }
-            size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
+            // Only include direct_map memory size if present
+            if (!ivf->direct_map.no()) {
+                size += ivf->ntotal * sizeof(idx_t);
+            }
         }
         *p_size = size;
     }
@@ -123,21 +118,6 @@ int faiss_Index_dist_compute(
 
         // If we get here, the index type doesn't support dist_compute
         return -1;
-    }
-    CATCH_AND_HANDLE
-}
-
-int faiss_Index_static_size(const FaissIndex* index, size_t* p_size) {
-    try {
-        const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
-        size_t size = faiss_index_static_size(idx);
-        // For IVF indices, include quantizer struct footprint
-        if (auto ivf = dynamic_cast<const faiss::IndexIVF*>(idx)) {
-            if (ivf->quantizer != nullptr) {
-                size += faiss_index_static_size(ivf->quantizer);
-            }
-        }
-        *p_size = size;
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -83,7 +83,6 @@ int faiss_Index_size(const FaissIndex* index, size_t* p_size) {
             if (ivfQuantizer != nullptr) {
                 size += faiss_index_static_size(ivfQuantizer);
             }
-            // Only include direct_map memory size if present
             if (!ivf->direct_map.no()) {
                 size += ivf->ntotal * sizeof(idx_t);
             }
@@ -121,5 +120,4 @@ int faiss_Index_dist_compute(
     }
     CATCH_AND_HANDLE
 }
-
 }

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -14,6 +14,8 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexScalarQuantizer.h>
 #include <faiss/IndexIVF.h>
+#include <faiss/IndexIVFFlat.h>
+#include <faiss/IndexIVFRaBitQ.h>
 
 extern "C" {
 
@@ -45,13 +47,17 @@ int faiss_Index_size(const FaissIndex* index, size_t* p_size) {
         const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
         // Base: raw vector codes (works for Flat, SQ, and all other types).
         size_t size = (size_t)idx->ntotal * idx->sa_code_size();
+        // Static struct footprint
+        size += faiss_index_static_size(idx);
         // IVF-specific overhead not captured by sa_code_size():
         //   centroids: quantizer->ntotal * quantizer->sa_code_size()
         //   stored IDs: ntotal * sizeof(idx_t)  (per-vector ID in each inverted list)
+        //   quantizer struct footprint
         if (auto ivf = dynamic_cast<const faiss::IndexIVF*>(idx)) {
             auto ivfQuantizer = ivf->quantizer;
             if (ivfQuantizer != nullptr) {
                 size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
+                size += faiss_index_static_size(ivfQuantizer);
             }
             size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
         }
@@ -88,4 +94,52 @@ int faiss_Index_dist_compute(
     }
     CATCH_AND_HANDLE
 }
+
+static size_t faiss_index_static_size(const faiss::Index* idx) {
+    if (idx == nullptr) {
+        return 0;
+    }
+    // Flat Index
+    if (dynamic_cast<const faiss::IndexFlat*>(idx)) {
+        return sizeof(faiss::IndexFlat);
+    }
+    // SQ Index
+    if (dynamic_cast<const faiss::IndexScalarQuantizer*>(idx)) {
+        return sizeof(faiss::IndexScalarQuantizer);
+    }
+    // IVF,SQ Index
+    if (dynamic_cast<const faiss::IndexIVFScalarQuantizer*>(idx)) {
+        return sizeof(faiss::IndexIVFScalarQuantizer);
+    }
+    // IVF,Flat Index
+    if (dynamic_cast<const faiss::IndexIVFFlat*>(idx)) {
+        return sizeof(faiss::IndexIVFFlat);
+    }
+    // IVF,RaBitQ Index
+    if (dynamic_cast<const faiss::IndexIVFRaBitQ*>(idx)) {
+        return sizeof(faiss::IndexIVFRaBitQ);
+    }
+    // IVF Index
+    if (dynamic_cast<const faiss::IndexIVF*>(idx)) {
+        return sizeof(faiss::IndexIVF);
+    }
+    // Base Index
+    return sizeof(faiss::Index);
+}
+
+int faiss_Index_static_size(const FaissIndex* index, size_t* p_size) {
+    try {
+        const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
+        size_t size = faiss_index_static_size(idx);
+        // For IVF indices, include quantizer struct footprint
+        if (auto ivf = dynamic_cast<const faiss::IndexIVF*>(idx)) {
+            if (ivf->quantizer != nullptr) {
+                size += faiss_index_static_size(ivf->quantizer);
+            }
+        }
+        *p_size = size;
+    }
+    CATCH_AND_HANDLE
+}
+
 }

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -40,7 +40,7 @@ int faiss_Index_merge_from(
     CATCH_AND_HANDLE
 }
 
-int faiss_Index_size(FaissIndex* index, size_t* p_size) {
+int faiss_Index_size(const FaissIndex* index, size_t* p_size) {
     try {
         const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
         // Base: raw vector codes (works for Flat, SQ, and all other types).

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -54,7 +54,6 @@ int faiss_Index_size(const FaissIndex* index, size_t* p_size) {
             size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
         }
         *p_size = size;
-        return 0;
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -13,6 +13,7 @@
 #include "macros_impl.h"
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexScalarQuantizer.h>
+#include <faiss/IndexIVF.h>
 
 extern "C" {
 
@@ -39,10 +40,23 @@ int faiss_Index_merge_from(
     CATCH_AND_HANDLE
 }
 
-size_t faiss_Index_size(FaissIndex* index) {
-    auto xIndex = reinterpret_cast<faiss::Index*>(index);
-    size_t rv = sizeof(xIndex);
-    return rv;
+int faiss_Index_size(FaissIndex* index, size_t* p_size) {
+    try {
+        const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
+        // Base: raw vector codes (works for Flat, SQ, and all other types).
+        size_t size = (size_t)idx->ntotal * idx->sa_code_size();
+        // IVF-specific overhead not captured by sa_code_size():
+        //   centroids: quantizer->ntotal * quantizer->sa_code_size()
+        //   stored IDs: ntotal * sizeof(idx_t)  (per-vector ID in each inverted list)
+        if (auto ivf = dynamic_cast<const faiss::IndexIVF*>(idx)) {
+            auto ivfQuantizer = ivf->quantizer;
+            size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
+            size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
+        }
+        *p_size = size;
+        return 0;
+    }
+    CATCH_AND_HANDLE
 }
 
 int faiss_Index_dist_compute(

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -50,7 +50,9 @@ int faiss_Index_size(const FaissIndex* index, size_t* p_size) {
         //   stored IDs: ntotal * sizeof(idx_t)  (per-vector ID in each inverted list)
         if (auto ivf = dynamic_cast<const faiss::IndexIVF*>(idx)) {
             auto ivfQuantizer = ivf->quantizer;
-            size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
+            if (ivfQuantizer != nullptr) {
+                size += (size_t)ivfQuantizer->ntotal * ivfQuantizer->sa_code_size();
+            }
             size += (size_t)ivf->ntotal * sizeof(faiss::idx_t);
         }
         *p_size = size;

--- a/c_api/Index_c_ex.cpp
+++ b/c_api/Index_c_ex.cpp
@@ -42,6 +42,38 @@ int faiss_Index_merge_from(
     CATCH_AND_HANDLE
 }
 
+static size_t faiss_index_static_size(const faiss::Index* idx) {
+    if (idx == nullptr) {
+        return 0;
+    }
+    // Flat Index
+    if (dynamic_cast<const faiss::IndexFlat*>(idx)) {
+        return sizeof(faiss::IndexFlat);
+    }
+    // SQ Index
+    if (dynamic_cast<const faiss::IndexScalarQuantizer*>(idx)) {
+        return sizeof(faiss::IndexScalarQuantizer);
+    }
+    // IVF,SQ Index
+    if (dynamic_cast<const faiss::IndexIVFScalarQuantizer*>(idx)) {
+        return sizeof(faiss::IndexIVFScalarQuantizer);
+    }
+    // IVF,Flat Index
+    if (dynamic_cast<const faiss::IndexIVFFlat*>(idx)) {
+        return sizeof(faiss::IndexIVFFlat);
+    }
+    // IVF,RaBitQ Index
+    if (dynamic_cast<const faiss::IndexIVFRaBitQ*>(idx)) {
+        return sizeof(faiss::IndexIVFRaBitQ);
+    }
+    // IVF Index
+    if (dynamic_cast<const faiss::IndexIVF*>(idx)) {
+        return sizeof(faiss::IndexIVF);
+    }
+    // Base Index
+    return sizeof(faiss::Index);
+}
+
 int faiss_Index_size(const FaissIndex* index, size_t* p_size) {
     try {
         const faiss::Index* idx = reinterpret_cast<const faiss::Index*>(index);
@@ -93,38 +125,6 @@ int faiss_Index_dist_compute(
         return -1;
     }
     CATCH_AND_HANDLE
-}
-
-static size_t faiss_index_static_size(const faiss::Index* idx) {
-    if (idx == nullptr) {
-        return 0;
-    }
-    // Flat Index
-    if (dynamic_cast<const faiss::IndexFlat*>(idx)) {
-        return sizeof(faiss::IndexFlat);
-    }
-    // SQ Index
-    if (dynamic_cast<const faiss::IndexScalarQuantizer*>(idx)) {
-        return sizeof(faiss::IndexScalarQuantizer);
-    }
-    // IVF,SQ Index
-    if (dynamic_cast<const faiss::IndexIVFScalarQuantizer*>(idx)) {
-        return sizeof(faiss::IndexIVFScalarQuantizer);
-    }
-    // IVF,Flat Index
-    if (dynamic_cast<const faiss::IndexIVFFlat*>(idx)) {
-        return sizeof(faiss::IndexIVFFlat);
-    }
-    // IVF,RaBitQ Index
-    if (dynamic_cast<const faiss::IndexIVFRaBitQ*>(idx)) {
-        return sizeof(faiss::IndexIVFRaBitQ);
-    }
-    // IVF Index
-    if (dynamic_cast<const faiss::IndexIVF*>(idx)) {
-        return sizeof(faiss::IndexIVF);
-    }
-    // Base Index
-    return sizeof(faiss::Index);
 }
 
 int faiss_Index_static_size(const FaissIndex* index, size_t* p_size) {

--- a/c_api/Index_c_ex.h
+++ b/c_api/Index_c_ex.h
@@ -28,12 +28,16 @@ int faiss_Index_reconstruct_batch(
 
 int faiss_Index_merge_from(FaissIndex* index, FaissIndex* other, idx_t add_id);
 
-/** Compute the size of the index in bytes, this includes the 
- *  size of the raw vector codes and any additional overhead 
- * (e.g. centroids, stored IDs) for IVF indices.
+/** Estimate the size of the index in bytes.
+ *
+ * The returned value is an approximation based on the stored vector
+ * codes and any additional known overhead (for example centroids and
+ * stored IDs for IVF indices). It does not imply an exact total memory
+ * footprint, and may not be available for index types that do not
+ * support this estimate.
  *
  * @param index       opaque pointer to index object
- * @param p_size      pointer to size_t to store the size
+ * @param p_size      pointer to size_t to store the estimated size
  */
 int faiss_Index_size(const FaissIndex* index, size_t* p_size);
 

--- a/c_api/Index_c_ex.h
+++ b/c_api/Index_c_ex.h
@@ -28,18 +28,25 @@ int faiss_Index_reconstruct_batch(
 
 int faiss_Index_merge_from(FaissIndex* index, FaissIndex* other, idx_t add_id);
 
-/** Estimate the size of the index in bytes.
+/** Return an approximate size estimate in bytes for the index.
+ * 
+ * The estimate accounts for stored codes, the base struct size, and for
+ * IVF-based indices, includes centroid and stored ID overhead.
  *
- * The returned value is an approximation based on the stored vector
- * codes and any additional known overhead (for example centroids and
- * stored IDs for IVF indices). It does not imply an exact total memory
- * footprint, and may not be available for index types that do not
- * support this estimate.
- *
- * @param index       opaque pointer to index object
- * @param p_size      pointer to size_t to store the estimated size
+ * @param index     opaque pointer to index object
+ * @param p_size    output approximate size in bytes
  */
 int faiss_Index_size(const FaissIndex* index, size_t* p_size);
+
+/** Return the static struct size of the index in bytes.
+ *
+ * This returns only the base struct footprint 
+ * without accounting for any stored data
+ *
+ * @param index     opaque pointer to index object
+ * @param p_size    output static size in bytes
+ */
+int faiss_Index_static_size(const FaissIndex* index, size_t* p_size);
 
 /** Compute distances between a query vector and a set of vectors 
  *

--- a/c_api/Index_c_ex.h
+++ b/c_api/Index_c_ex.h
@@ -28,7 +28,14 @@ int faiss_Index_reconstruct_batch(
 
 int faiss_Index_merge_from(FaissIndex* index, FaissIndex* other, idx_t add_id);
 
-size_t faiss_Index_size(FaissIndex* index);
+/** Compute the size of the index in bytes, this includes the 
+ *  size of the raw vector codes and any additional overhead 
+ * (e.g. centroids, stored IDs) for IVF indices.
+ *
+ * @param index       opaque pointer to index object
+ * @param p_size      pointer to size_t to store the size
+ */
+int faiss_Index_size(FaissIndex* index, size_t* p_size);
 
 /** Compute distances between a query vector and a set of vectors 
  *

--- a/c_api/Index_c_ex.h
+++ b/c_api/Index_c_ex.h
@@ -30,23 +30,11 @@ int faiss_Index_merge_from(FaissIndex* index, FaissIndex* other, idx_t add_id);
 
 /** Return an approximate size estimate in bytes for the index.
  * 
- * The estimate accounts for stored codes, the base struct size, and for
- * IVF-based indices, includes centroid and stored ID overhead.
  *
  * @param index     opaque pointer to index object
  * @param p_size    output approximate size in bytes
  */
 int faiss_Index_size(const FaissIndex* index, size_t* p_size);
-
-/** Return the static struct size of the index in bytes.
- *
- * This returns only the base struct footprint 
- * without accounting for any stored data
- *
- * @param index     opaque pointer to index object
- * @param p_size    output static size in bytes
- */
-int faiss_Index_static_size(const FaissIndex* index, size_t* p_size);
 
 /** Compute distances between a query vector and a set of vectors 
  *

--- a/c_api/Index_c_ex.h
+++ b/c_api/Index_c_ex.h
@@ -35,7 +35,7 @@ int faiss_Index_merge_from(FaissIndex* index, FaissIndex* other, idx_t add_id);
  * @param index       opaque pointer to index object
  * @param p_size      pointer to size_t to store the size
  */
-int faiss_Index_size(FaissIndex* index, size_t* p_size);
+int faiss_Index_size(const FaissIndex* index, size_t* p_size);
 
 /** Compute distances between a query vector and a set of vectors 
  *


### PR DESCRIPTION
- We currently return `8` bytes for the `faiss_IndexBinary_size` and the 
  `faiss_Index_size` APIs, this is because we use the `sizeof()` operator on a pointer.
- This leads to undercounting in the amount of memory actually used by the index, since
  we fail to account for its actual size, which includes the struct's static size and 
  the direct map.
- Fix this issue by measuring the static struct size and the direct map size to 
  return a more accurate estimate.