### PR TITLE
Removing resize operation while merging

### DIFF
--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -368,7 +368,6 @@ void IndexBinaryIVF::merge_from(IndexBinary& otherIndex, idx_t add_id) {
     auto other = static_cast<IndexBinaryIVF*>(&otherIndex);
     invlists->merge_from(other->invlists, add_id);
     ntotal += other->ntotal;
-    other->ntotal = 0;
 }
 
 void IndexBinaryIVF::replace_invlists(InvertedLists* il, bool own) {

--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -106,7 +106,6 @@ void IndexFlatCodes::merge_from(Index& otherIndex, idx_t add_id) {
            src,
            other->ntotal * code_size);
     ntotal += other->ntotal;
-    other->reset();
 }
 
 CodePacker* IndexFlatCodes::get_CodePacker() const {

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -1325,7 +1325,6 @@ void IndexIVF::merge_from(Index& otherIndex, idx_t add_id) {
     invlists->merge_from(other->invlists, add_id);
 
     ntotal += other->ntotal;
-    other->ntotal = 0;
 }
 
 CodePacker* IndexIVF::get_CodePacker() const {

--- a/faiss/invlists/InvertedLists.cpp
+++ b/faiss/invlists/InvertedLists.cpp
@@ -84,7 +84,6 @@ void InvertedLists::merge_from(InvertedLists* oivf, size_t add_id) {
             add_entries(
                     i, list_size, new_ids.data(), ScopedCodes(oivf, i).get());
         }
-        oivf->resize(i, 0);
     }
 }
 


### PR DESCRIPTION
 - Faiss assumes the other index will not be used after the merge operation
 - But this is not true since the older segment data will still be in use and cannot be mutated