### PR TITLE
MB-71397: Add getter for BinaryCodeSize

### DIFF
--- a/c_api/IndexBinary_c_ex.cpp
+++ b/c_api/IndexBinary_c_ex.cpp
@@ -68,4 +68,12 @@ int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size) {
     }
     CATCH_AND_HANDLE
 }
+
+int faiss_IndexBinary_sa_code_size(const FaissIndexBinary* index, size_t* size) {
+    try {
+        *size = reinterpret_cast<const faiss::IndexBinary*>(index)->sa_code_size();
+    }
+    CATCH_AND_HANDLE
+}
+
 }

--- a/c_api/IndexBinary_c_ex.h
+++ b/c_api/IndexBinary_c_ex.h
@@ -46,6 +46,13 @@ int faiss_IndexBinary_search_with_params(
  */
 int faiss_IndexBinary_size(const FaissIndexBinary* index, size_t* p_size);
 
+/** The size of the produced codes in bytes.
+ *
+ * @param index   opaque pointer to index object
+ * @param size    the returned size in bytes
+ */
+int faiss_IndexBinary_sa_code_size(const FaissIndexBinary* index, size_t* size);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Add an C API to retrieve the code_size for BIVF class.