### PR TITLE
Add C API to binarize vectors

### DIFF
--- a/c_api/utils/utils_c.cpp
+++ b/c_api/utils/utils_c.cpp
@@ -15,6 +15,13 @@ const char* faiss_get_version() {
     return VERSION_STRING;
 }
 
-void faiss_real_to_binary(size_t d, const float* x_in, uint8_t* x_out) {
-    faiss::real_to_binary(d, x_in, x_out);
+void faiss_real_to_binary(
+        size_t n,
+        size_t d,
+        const float* x_in,
+        uint8_t* x_out) {
+    const size_t out_stride = d / 8;
+    for (size_t i = 0; i < n; ++i) {
+        faiss::real_to_binary(d, x_in + i * d, x_out + i * out_stride);
+    }
 }

--- a/c_api/utils/utils_c.cpp
+++ b/c_api/utils/utils_c.cpp
@@ -9,7 +9,12 @@
 
 #include "utils_c.h"
 #include <faiss/Index.h>
+#include <faiss/utils/utils.h>
 
 const char* faiss_get_version() {
     return VERSION_STRING;
+}
+
+void faiss_real_to_binary(size_t d, const float* x_in, uint8_t* x_out) {
+    faiss::real_to_binary(d, x_in, x_out);
 }

--- a/c_api/utils/utils_c.h
+++ b/c_api/utils/utils_c.h
@@ -19,6 +19,17 @@ extern "C" {
 
 const char* faiss_get_version();
 
+/** Convert a real-valued vector to a binary vector.
+ *
+ * Each bit in the output is set to 1 if the corresponding input value is
+ * greater than 0, and 0 otherwise.
+ *
+ * @param d      dimension of the input vector (must be a multiple of 8)
+ * @param x_in   input float vector (float table of size d)
+ * @param x_out  output binary vector (uint8_t table of size d / 8)
+ */
+void faiss_real_to_binary(size_t d, const float* x_in, uint8_t* x_out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c_api/utils/utils_c.h
+++ b/c_api/utils/utils_c.h
@@ -19,16 +19,21 @@ extern "C" {
 
 const char* faiss_get_version();
 
-/** Convert a real-valued vector to a binary vector.
+/** Convert real-valued vectors to binary vectors.
  *
  * Each bit in the output is set to 1 if the corresponding input value is
  * greater than 0, and 0 otherwise.
  *
- * @param d      dimension of the input vector (must be a multiple of 8)
- * @param x_in   input float vector (float table of size d)
- * @param x_out  output binary vector (uint8_t table of size d / 8)
+ * @param n      number of vectors
+ * @param d      dimension of each input vector (must be a multiple of 8)
+ * @param x_in   input float vectors (float table of size n * d)
+ * @param x_out  output binary vectors (uint8_t table of size n * (d / 8))
  */
-void faiss_real_to_binary(size_t d, const float* x_in, uint8_t* x_out);
+void faiss_real_to_binary(
+        size_t n,
+        size_t d,
+        const float* x_in,
+        uint8_t* x_out);
 
 #ifdef __cplusplus
 }

--- a/c_api/utils/utils_c.h
+++ b/c_api/utils/utils_c.h
@@ -21,8 +21,9 @@ const char* faiss_get_version();
 
 /** Convert real-valued vectors to binary vectors.
  *
- * Each bit in the output is set to 1 if the corresponding input value is
- * greater than 0, and 0 otherwise.
+ * Bits are packed LSB-first within each output byte: bit j corresponds to
+ * x_in[8 * i + j] for output byte i. A bit is set to 1 if the corresponding
+ * input value is greater than 0, and 0 otherwise.
  *
  * @param n      number of vectors
  * @param d      dimension of each input vector (must be a multiple of 8)


### PR DESCRIPTION
- Add a C binding for the `real_to_binary` API that binarizes a batch of `n * d` input vector table in LSB format.