### PR TITLE
MB-72240: clone the quantizers during fast merge

### DIFF
--- a/c_api/IndexBinaryIVF_c_ex.cpp
+++ b/c_api/IndexBinaryIVF_c_ex.cpp
@@ -9,6 +9,7 @@
 
 #include "IndexBinaryIVF_c_ex.h"
 #include <faiss/IndexBinaryIVF.h>
+#include <faiss/clone_index.h>
 #include "macros_impl.h"
 
 using faiss::IndexBinaryIVF;
@@ -111,7 +112,7 @@ int faiss_Set_quantizers_binary(FaissIndexBinary* target, FaissIndexBinary* sour
             auto* src_bivf = dynamic_cast<faiss::IndexBinaryIVF*>(src);
             assert(src_bivf);
 
-            tgt_bivf->quantizer = src_bivf->quantizer;
+            tgt_bivf->quantizer = clone_binary_index(src_bivf->quantizer);
             tgt_bivf->is_trained = true;
             return 0;
         }

--- a/c_api/IndexIVF_c_ex.cpp
+++ b/c_api/IndexIVF_c_ex.cpp
@@ -74,7 +74,7 @@ int faiss_Set_quantizers(FaissIndex* target, FaissIndex* source) {
             auto* src_ivfsq = dynamic_cast<faiss::IndexIVFScalarQuantizer*>(src);
             assert(src_ivfsq);
 
-            tgt_ivfsq->quantizer = src_ivfsq->quantizer;
+            tgt_ivfsq->quantizer = clone_index(src_ivfsq->quantizer);
             tgt_ivfsq->is_trained = true;
             tgt_ivfsq->sq = src_ivfsq->sq;
             return 0;
@@ -95,7 +95,7 @@ int faiss_Set_quantizers(FaissIndex* target, FaissIndex* source) {
             auto* src_rabitq = dynamic_cast<faiss::IndexIVFRaBitQ*>(src);
             assert(src_rabitq);
 
-            tgt_rabitq->quantizer = src_rabitq->quantizer;
+            tgt_rabitq->quantizer = clone_index(src_rabitq->quantizer);
             tgt_rabitq->is_trained = true;
             tgt_rabitq->rabitq = src_rabitq->rabitq;
             return 0;


### PR DESCRIPTION
- the upstream code in zap maintains the trained index in a cache that would be a shared object. this would require the underlying faiss layer to copy the quantizers to avoid panics/corruption issues