### PR TITLE
MB-72221: Reusable GPU Events 

### DIFF
--- a/faiss/gpu/GpuResources.h
+++ b/faiss/gpu/GpuResources.h
@@ -251,6 +251,11 @@ class GpuResources {
     /// Returns the stream on which we perform async CPU <-> GPU copies
     virtual cudaStream_t getAsyncCopyStream(int device) = 0;
 
+    /// Synchronize the given stream(s) to wait for the completion of the other stream(s). 
+    virtual void streamWait(
+        const std::vector<cudaStream_t>& waiting,
+        const std::initializer_list<cudaStream_t>& waitOn) = 0;
+
     ///
     /// Functions provided by default
     ///

--- a/faiss/gpu/GpuResources.h
+++ b/faiss/gpu/GpuResources.h
@@ -251,10 +251,11 @@ class GpuResources {
     /// Returns the stream on which we perform async CPU <-> GPU copies
     virtual cudaStream_t getAsyncCopyStream(int device) = 0;
 
-    /// Synchronize the given stream(s) to wait for the completion of the other stream(s). 
+    /// Synchronize the given stream(s) to wait for the completion of the other
+    /// stream(s).
     virtual void streamWait(
-        const std::vector<cudaStream_t>& waiting,
-        const std::initializer_list<cudaStream_t>& waitOn) = 0;
+            const std::vector<cudaStream_t>& waiting,
+            const std::vector<cudaStream_t>& waitOn) = 0;
 
     ///
     /// Functions provided by default

--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -135,6 +135,10 @@ StandardGpuResourcesImpl::~StandardGpuResourcesImpl() {
     raftHandles_.clear();
 #endif
 
+    for (auto& entry : streamEvents_) {
+        CUDA_VERIFY(cudaEventDestroy(entry.second));
+    }
+
     for (auto& entry : defaultStreams_) {
         DeviceScope scope(entry.first);
 
@@ -205,6 +209,14 @@ size_t StandardGpuResourcesImpl::getDefaultTempMemForGPU(
 
     // use whatever lower limit the user requested
     return requested;
+}
+
+void StandardGpuResourcesImpl::addEventForStream(cudaStream_t stream) {
+    if (streamEvents_.count(stream) == 0) {
+        cudaEvent_t event = nullptr;
+        CUDA_VERIFY(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+        streamEvents_.emplace(stream, event);
+    }
 }
 
 /// Does the given GPU support bfloat16?
@@ -287,6 +299,7 @@ void StandardGpuResourcesImpl::setDefaultStream(
 #endif
     }
 
+    addEventForStream(stream);
     userDefaultStreams_[device] = stream;
 }
 
@@ -414,6 +427,7 @@ void StandardGpuResourcesImpl::initializeForDevice(int device) {
             cudaStreamCreateWithFlags(&defaultStream, cudaStreamNonBlocking));
 
     defaultStreams_[device] = defaultStream;
+    addEventForStream(defaultStream);
 
 #if defined USE_NVIDIA_CUVS
     raftHandles_.emplace(std::make_pair(device, defaultStream));
@@ -424,11 +438,13 @@ void StandardGpuResourcesImpl::initializeForDevice(int device) {
             cudaStreamCreateWithFlags(&asyncCopyStream, cudaStreamNonBlocking));
 
     asyncCopyStreams_[device] = asyncCopyStream;
+    addEventForStream(asyncCopyStream);
 
     std::vector<cudaStream_t> deviceStreams;
     for (int j = 0; j < kNumStreams; ++j) {
         cudaStream_t stream = nullptr;
         CUDA_VERIFY(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+        addEventForStream(stream);
 
         deviceStreams.push_back(stream);
     }
@@ -704,6 +720,27 @@ StandardGpuResourcesImpl::getMemoryInfo() const {
     }
 
     return out;
+}
+
+void StandardGpuResourcesImpl::streamWait(
+        const std::vector<cudaStream_t>& listWaiting,
+        const std::vector<cudaStream_t>& listWaitOn) {
+
+    std::vector<cudaEvent_t> events;
+    for (auto& stream : listWaitOn) {
+        FAISS_ASSERT(streamEvents_.count(stream) != 0);
+        cudaEvent_t event = streamEvents_[stream];
+
+        CUDA_VERIFY(cudaEventRecord(event, stream));
+        events.push_back(event);
+    }
+
+    // For all the streams that are waiting, issue a wait
+    for (auto& stream : listWaiting) {
+        for (auto& event : events) {
+            CUDA_VERIFY(cudaStreamWaitEvent(stream, event, 0));
+        }
+    }
 }
 
 //

--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -725,7 +725,6 @@ StandardGpuResourcesImpl::getMemoryInfo() const {
 void StandardGpuResourcesImpl::streamWait(
         const std::vector<cudaStream_t>& listWaiting,
         const std::vector<cudaStream_t>& listWaitOn) {
-
     std::vector<cudaEvent_t> events;
     for (auto& stream : listWaitOn) {
         FAISS_ASSERT(streamEvents_.count(stream) != 0);

--- a/faiss/gpu/StandardGpuResources.h
+++ b/faiss/gpu/StandardGpuResources.h
@@ -141,7 +141,7 @@ class StandardGpuResourcesImpl : public GpuResources {
     /// memory size
     static size_t getDefaultTempMemForGPU(int device, size_t requested);
 
-    static void addEventForStream(cudaStream_t stream);
+    void addEventForStream(cudaStream_t stream);
 
    protected:
     /// Set of currently outstanding memory allocations per device

--- a/faiss/gpu/StandardGpuResources.h
+++ b/faiss/gpu/StandardGpuResources.h
@@ -129,6 +129,8 @@ class StandardGpuResourcesImpl : public GpuResources {
 
     cudaStream_t getAsyncCopyStream(int device) override;
 
+    void streamWait(const std::vector<cudaStream_t>& waitStreams, const std::vector<cudaStream_t>& signalStreams);
+
    protected:
     /// Have GPU resources been initialized for this device yet?
     bool isInitialized(int device) const;
@@ -136,6 +138,8 @@ class StandardGpuResourcesImpl : public GpuResources {
     /// Adjust the default temporary memory allocation based on the total GPU
     /// memory size
     static size_t getDefaultTempMemForGPU(int device, size_t requested);
+
+    static void addEventForStream(cudaStream_t stream);
 
    protected:
     /// Set of currently outstanding memory allocations per device
@@ -160,6 +164,9 @@ class StandardGpuResourcesImpl : public GpuResources {
 
     /// cuBLAS handle for each device
     std::unordered_map<int, cublasHandle_t> blasHandles_;
+
+    /// Reusable CUDA event, one per stream managed by this resource
+    std::unordered_map<cudaStream_t, cudaEvent_t> streamEvents_;
 
 #if defined USE_NVIDIA_CUVS
     /// raft handle for each device

--- a/faiss/gpu/StandardGpuResources.h
+++ b/faiss/gpu/StandardGpuResources.h
@@ -129,7 +129,9 @@ class StandardGpuResourcesImpl : public GpuResources {
 
     cudaStream_t getAsyncCopyStream(int device) override;
 
-    void streamWait(const std::vector<cudaStream_t>& waitStreams, const std::vector<cudaStream_t>& signalStreams);
+    void streamWait(
+            const std::vector<cudaStream_t>& waitStreams,
+            const std::vector<cudaStream_t>& signalStreams);
 
    protected:
     /// Have GPU resources been initialized for this device yet?

--- a/faiss/gpu/StandardGpuResources.h
+++ b/faiss/gpu/StandardGpuResources.h
@@ -129,9 +129,11 @@ class StandardGpuResourcesImpl : public GpuResources {
 
     cudaStream_t getAsyncCopyStream(int device) override;
 
+    /// Synchronize the given stream(s) to wait for the completion of the other
+    /// stream(s).
     void streamWait(
-            const std::vector<cudaStream_t>& waitStreams,
-            const std::vector<cudaStream_t>& signalStreams);
+            const std::vector<cudaStream_t>& waiting,
+            const std::vector<cudaStream_t>& waitOn);
 
    protected:
     /// Have GPU resources been initialized for this device yet?

--- a/faiss/gpu/impl/Distance.cu
+++ b/faiss/gpu/impl/Distance.cu
@@ -235,7 +235,7 @@ void runDistance(
             &outIndexBuf1, &outIndexBuf2};
 
     auto streams = res->getAlternateStreamsCurrentDevice();
-    streamWait(streams, {stream});
+    res->streamWait(streams, {stream});
 
     int curStream = 0;
     bool interrupt = false;
@@ -398,7 +398,7 @@ void runDistance(
     }
 
     // Have the desired ordering stream wait on the multi-stream
-    streamWait({stream}, streams);
+    res->streamWait({stream}, streams);
 
     if (interrupt) {
         FAISS_THROW_MSG("interrupted");

--- a/faiss/gpu/impl/GeneralDistance.cuh
+++ b/faiss/gpu/impl/GeneralDistance.cuh
@@ -351,7 +351,7 @@ void runGeneralDistance(
             &outIndexBuf1, &outIndexBuf2};
 
     auto streams = res->getAlternateStreamsCurrentDevice();
-    streamWait(streams, {stream});
+    res->streamWait(streams, {stream});
 
     int curStream = 0;
     bool interrupt = false;
@@ -448,7 +448,7 @@ void runGeneralDistance(
     }
 
     // Have the desired ordering stream wait on the multi-stream
-    streamWait({stream}, streams);
+    res->streamWait({stream}, streams);
 
     if (interrupt) {
         FAISS_THROW_MSG("interrupted");

--- a/faiss/gpu/impl/IVFFlatScan.cu
+++ b/faiss/gpu/impl/IVFFlatScan.cu
@@ -434,7 +434,7 @@ void runIVFFlatScan(
             &heapIndices1, &heapIndices2};
 
     auto streams = res->getAlternateStreamsCurrentDevice();
-    streamWait(streams, {stream});
+    res->streamWait(streams, {stream});
 
     int curStream = 0;
 
@@ -487,7 +487,7 @@ void runIVFFlatScan(
         curStream = (curStream + 1) % 2;
     }
 
-    streamWait({stream}, streams);
+    res->streamWait({stream}, streams);
 }
 
 } // namespace gpu

--- a/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
@@ -673,7 +673,7 @@ void runPQScanMultiPassNoPrecomputed(
             &heapIndices1, &heapIndices2};
 
     auto streams = res->getAlternateStreamsCurrentDevice();
-    streamWait(streams, {stream});
+    res->streamWait(streams, {stream});
 
     int curStream = 0;
 
@@ -736,7 +736,7 @@ void runPQScanMultiPassNoPrecomputed(
         curStream = (curStream + 1) % 2;
     }
 
-    streamWait({stream}, streams);
+    res->streamWait({stream}, streams);
 }
 
 } // namespace gpu

--- a/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
+++ b/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
@@ -658,7 +658,7 @@ void runPQScanMultiPassPrecomputed(
             &heapIndices1, &heapIndices2};
 
     auto streams = res->getAlternateStreamsCurrentDevice();
-    streamWait(streams, {stream});
+    res->streamWait(streams, {stream});
 
     int curStream = 0;
 
@@ -716,7 +716,7 @@ void runPQScanMultiPassPrecomputed(
         curStream = (curStream + 1) % 2;
     }
 
-    streamWait({stream}, streams);
+    res->streamWait({stream}, streams);
 }
 
 } // namespace gpu

--- a/faiss/gpu/utils/StackDeviceMemory.cpp
+++ b/faiss/gpu/utils/StackDeviceMemory.cpp
@@ -103,7 +103,7 @@ char* StackDeviceMemory::Stack::getAlloc(size_t size, cudaStream_t stream) {
 
         if (stream != prevUser.stream_) {
             // Synchronization required
-            res->streamWait({stream}, {prevUser.stream_});
+            res_->streamWait({stream}, {prevUser.stream_});
         }
 
         if (endAlloc < prevUser.end_) {

--- a/faiss/gpu/utils/StackDeviceMemory.cpp
+++ b/faiss/gpu/utils/StackDeviceMemory.cpp
@@ -103,7 +103,7 @@ char* StackDeviceMemory::Stack::getAlloc(size_t size, cudaStream_t stream) {
 
         if (stream != prevUser.stream_) {
             // Synchronization required
-            streamWait({stream}, {prevUser.stream_});
+            res->streamWait({stream}, {prevUser.stream_});
         }
 
         if (endAlloc < prevUser.end_) {


### PR DESCRIPTION
- Currently, the GPU utilizes multiple CUDA streams for distance computation and 
  uses CUDA events for stream synchronization.
- However, this synchronization happens via the creation of short-lived CUDA event objects, 
  leading to CUDA runtime stalls during QPS benchmarking.
- According [to the CUDA docs](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EVENT.html#group__CUDART__EVENT_1gf4fcb74343aa689f4159791967868446), we can reuse the CUDA event objects, avoiding the 
  potentially synchronizing `cudaEventCreate` calls whereas a plain `cudaEventRecord` is explicitly async.
- Nsight profile before: `cudaEventCreateWithFlags` being a hot bottleneck in performance.

```log
 ** CUDA API Summary (cuda_api_sum):

 Time (%)  Total Time (ns)  Num Calls     Avg (ns)         Med (ns)       Min (ns)      Max (ns)      StdDev (ns)                Name             
 --------  ---------------  ---------  ---------------  ---------------  -----------  -------------  -------------  ------------------------------
     37.2  210,711,756,191    479,900        439,074.3         70,058.5            0     60,234,078    1,721,106.5  cudaEventCreateWithFlags      
     16.3   92,063,460,631    479,574        191,969.2          5,140.0            0     49,381,578      872,837.6  cudaEventDestroy              
     15.4   87,072,524,141    934,762         93,149.4         18,240.0            0     34,857,402      404,908.5  cudaMemcpyAsync  
...

Processing [/tmp/nsys-report-bb07.sqlite] with [/opt/nvidia/nsight-systems/2025.3.2/host-linux-x64/reports/cuda_gpu_kern_sum.py]... 

 ** CUDA GPU Kernel Summary (cuda_gpu_kern_sum):

 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)   StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  ---------  ---------  --------  ---------  -----------  ----------------------------------------------------------------------------------------------------
     76.8   33,530,500,505    114,412  293,068.0  281,730.0    83,937  3,948,871     51,606.3  void faiss::gpu::ivfInterleavedScan<faiss::gpu::Codec<(int)0, (int)1>, faiss::gpu::IPDistance, (int…
     15.0    6,560,922,914     45,443  144,377.0  137,922.0    26,976  2,352,494     51,350.5  void faiss::gpu::ivfInterleavedScan<faiss::gpu::CodecFloat, faiss::gpu::IPDistance, (int)128, (int)…
      1.9      839,912,396    159,855    5,254.2    5,184.0     3,200    470,245      2,173.6  void faiss::gpu::ivfInterleavedScan2<(int)128, (int)32, (int)2>(faiss::gpu::Tensor<float, (int)3, (…
      1.9      821,931,726     60,698   13,541.3   12,512.0     9,696    334,916      3,554.4  void faiss::gpu::blockSelect<float, long, (bool)1, (int)64, (int)3, (int)128>(faiss::gpu::Tensor<T1…
      1.3      550,003,854     43,849   12,543.1   11,424.0     3,424  3,678,616     28,382.5  std::enable_if<!T7, void>::type internal::gemvx::kernel<int, int, float, float, float, float, (bool…
      1.0      418,632,073     99,160    4,221.8    3,456.0     2,720  1,762,346      7,322.3  void faiss::gpu::blockSelect<float, long, (bool)1, (int)32, (int)2, (int)128>(faiss::gpu::Tensor<T1…
      0.5      209,241,485    114,412    1,828.8    1,568.0     1,024  3,049,565     16,486.7  void faiss::gpu::gatherReconstructByIds<float>(faiss::gpu::Tensor<long, (int)1, (bool)1, long, fais…
      0.3      129,061,998     16,942    7,617.9    4,928.0     2,880  2,267,797     21,470.4  void gemmSN_TN_kernel<float, (int)128, (int)16, (int)2, (int)4, (int)2, (int)2, (bool)1, cublasGemv…
````
- Nsight profile after: CUDA event churn is absent.

```log
 ** CUDA API Summary (cuda_api_sum):\
\
 Time (%)  Total Time (ns)  Num Calls   Avg (ns)     Med (ns)    Min (ns)    Max (ns)   StdDev (ns)               Name             \
 --------  ---------------  ---------  -----------  -----------  ---------  ----------  -----------  ------------------------------\
     64.3   36,524,350,119    496,155     73,614.8      9,369.0          0  22,393,005    319,435.5  cudaMemcpyAsync               \
     13.3    7,566,285,819    418,673     18,072.1      7,215.0          0  21,027,398    176,730.7  cudaLaunchKernel              \
      9.9    5,599,614,594     21,907    255,608.5      8,390.0          0  21,812,772  1,072,698.5  cudaMalloc                    \
      3.8    2,167,414,136    335,764      6,455.2      3,950.0          0   6,635,645     57,756.8  cudaStreamWaitEvent           \
      3.6    2,068,189,336    285,314      7,248.8      2,647.0          0  13,957,338    131,293.0  cudaEventRecord               \
...

Processing [/tmp/profile_e3JBBX.sqlite] with [/opt/nvidia/nsight-systems/2025.3.2/host-linux-x64/reports/cuda_gpu_kern_sum.py]... \
\
 ** CUDA GPU Kernel Summary (cuda_gpu_kern_sum):\
\
 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                \
 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------\
     75.9   15,951,402,052     49,386  322,994.4  292,930.5    97,345   567,460     86,631.7  void faiss::gpu::ivfInterleavedScan<faiss::gpu::Codec<(int)0, (int)1>, faiss::gpu::IPDistance, (int\'85\
     16.1    3,392,001,637     34,555   98,162.4   85,057.0    28,800   223,458     33,226.4  void faiss::gpu::ivfInterleavedScan<faiss::gpu::CodecFloat, faiss::gpu::IPDistance, (int)128, (int)\'85\
      2.0      423,606,303     83,941    5,046.5    4,320.0     3,136    22,881      1,537.0  void faiss::gpu::ivfInterleavedScan2<(int)128, (int)32, (int)2>(faiss::gpu::Tensor<float, (int)3, (\'85\
      1.9      400,850,396     17,548   22,843.1   22,912.0    19,296    53,409      1,372.3  void faiss::gpu::blockSelect<float, long, (bool)1, (int)128, (int)3, (int)128>(faiss::gpu::Tensor<T\'85\
      1.3      272,777,375     66,393    4,108.5    3,392.0     2,752    23,808      1,425.1  void faiss::gpu::blockSelect<float, long, (bool)1, (int)32, (int)2, (int)128>(faiss::gpu::Tensor<T1\'85\
      0.5      101,674,739      9,836   10,337.0    5,600.0     5,088    31,105      6,860.0  void gemv2T_kernel_val<int, int, float, float, float, float, (int)128, (int)16, (int)4, (int)4, (bo\'85\
      0.3       72,242,590     49,386    1,462.8    1,344.0       992    20,128        461.9  void faiss::gpu::gatherReconstructByIds<float>(faiss::gpu::Tensor<long, (int)1, (bool)1, long, fais\'85\
      0.3       64,048,147     11,640    5,502.4    4,480.0     2,816    26,688      4,114.7  void gemmSN_TN_kernel<float, (int)128, (int)16, (int)2, (int)4, (int)2, (int)2, (bool)1, cublasGemv\'85\
```