### PR TITLE
MB-72446: Asynchronous GPU memory allocation

### DIFF
--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -582,7 +582,7 @@ void* StandardGpuResourcesImpl::allocMemory(const AllocRequest& req) {
             FAISS_THROW_MSG("CUDA memory allocation error");
         }
 #else
-        auto err = cudaMalloc(&p, adjReq.size);
+        auto err = cudaMallocAsync(&p, adjReq.size, adjReq.stream);
 
         // Throw if we fail to allocate
         if (err != cudaSuccess) {
@@ -671,9 +671,19 @@ void StandardGpuResourcesImpl::deallocMemory(int device, void* p) {
 
     if (req.space == MemorySpace::Temporary) {
         tempMemory_[device]->deallocMemory(device, req.stream, req.size, p);
-    } else if (
-            req.space == MemorySpace::Device ||
-            req.space == MemorySpace::Unified) {
+    } else if (req.space == MemorySpace::Device ) {
+#if defined USE_NVIDIA_CUVS
+        req.mr->deallocate_async(p, req.size, req.stream);
+#else
+        auto err = cudaFreeAsync(p, req.stream);
+        FAISS_ASSERT_FMT(
+                err == cudaSuccess,
+                "Failed to cudaFree pointer %p (error %d %s)",
+                p,
+                (int)err,
+                cudaGetErrorString(err));
+#endif
+    } else if (req.space == MemorySpace::Unified) {
 #if defined USE_NVIDIA_CUVS
         req.mr->deallocate_async(p, req.size, req.stream);
 #else

--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -671,7 +671,7 @@ void StandardGpuResourcesImpl::deallocMemory(int device, void* p) {
 
     if (req.space == MemorySpace::Temporary) {
         tempMemory_[device]->deallocMemory(device, req.stream, req.size, p);
-    } else if (req.space == MemorySpace::Device ) {
+    } else if (req.space == MemorySpace::Device) {
 #if defined USE_NVIDIA_CUVS
         req.mr->deallocate_async(p, req.size, req.stream);
 #else

--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -593,7 +593,7 @@ void* StandardGpuResourcesImpl::allocMemory(const AllocRequest& req) {
 
             std::stringstream ss;
             ss << "StandardGpuResources: alloc fail " << adjReq.toString()
-               << " (cudaMalloc error " << cudaGetErrorString(err) << " ["
+               << " (cudaMallocAsync error " << cudaGetErrorString(err) << " ["
                << (int)err << "])\n";
             auto str = ss.str();
 
@@ -678,7 +678,7 @@ void StandardGpuResourcesImpl::deallocMemory(int device, void* p) {
         auto err = cudaFreeAsync(p, req.stream);
         FAISS_ASSERT_FMT(
                 err == cudaSuccess,
-                "Failed to cudaFree pointer %p (error %d %s)",
+                "Failed to cudaFreeAsync pointer %p (error %d %s)",
                 p,
                 (int)err,
                 cudaGetErrorString(err));


### PR DESCRIPTION
- Currently we use `cudaMalloc` and `cudaFree` for `Device` space allocations, without any stream ordering.
- `CUDA` supports stream ordered allocation using `cudaMallocAsync` and `cudaFreeAsync` from CUDA toolkit version 11.2 onwards.
- We should be using the stream-ordered variant akin to the stream-ordered variant used by RMM when cuVS is enabled.