### PR TITLE
MB-72667: clear IndexFlatCodes only if it owns the underlying data

### DIFF
--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -106,7 +106,9 @@ void IndexFlatCodes::merge_from(Index& otherIndex, idx_t add_id) {
            src,
            other->ntotal * code_size);
     ntotal += other->ntotal;
-    other->reset();
+    if (other->codes.is_owned) {
+        other->reset();
+    }
 }
 
 CodePacker* IndexFlatCodes::get_CodePacker() const {


### PR DESCRIPTION
- fixes a bug that wasn't handled in https://github.com/blevesearch/faiss/pull/79