### PR TITLE
MB-73359: keep residual buffer alive in compute_distance_to_codes_for…

### DIFF
--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -334,9 +334,14 @@ void IndexIVFScalarQuantizer::compute_distance_to_codes_for_list(
 
     dc->code_size = sq.code_size;
 
+    // NOTE: set_query() only stores the query pointer, it does not copy, so
+    // the residual buffer must outlive the distance_to_codes() call below.
+    // Declaring it inside the if-block would leave dc->q dangling.
+    std::vector<float> tmp;
+
     if (by_residual) {
         // shift of x_in wrt centroid
-        std::vector<float> tmp(d);
+        tmp.resize(d);
         quantizer->compute_residual(x, tmp.data(), list_no);
         dc->set_query(tmp.data());
     } else {


### PR DESCRIPTION
…_list

IndexIVFScalarQuantizer::compute_distance_to_codes_for_list() declared the residual buffer inside the `if (by_residual)` block, so it was destroyed at the closing brace. SQDistanceComputer::set_query() only stores the query pointer (`const float* q` in FlatCodesDistanceComputer) and does not copy, so the following dc->distance_to_codes() read freed heap memory.

Hoist `tmp` to function scope. The scanner form of this same computation (IVFSQScannerL2::set_list in impl/ScalarQuantizer.cpp) already holds `tmp` as a member for exactly this reason; the standalone function got the lifetime wrong when it was added.

Reachable from GSI whenever a BHIVE vector index uses SQ with METRIC_L2, on both the graph-build and the scan path. Observed as an 0xC0000005 access violation during BHIVE graph build on Windows; on other platforms the same defect silently corrupts the computed distances.